### PR TITLE
[ci] support 7.x stack version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,12 +13,16 @@ pipeline {
             }
         }
 
-        stage ('Build') {
+        stage ('Run tests') {
             steps {
                 withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY')  {
                     sh """
                         cd kibana-load-testing
-                        export cloudDeploy=${params.STACK_VERSION}
+                        if [ "${params.STACK_VERSION}" = "7.x" ]; then
+                            export cloudDeploy=7.12.0-SNAPSHOT
+                        else
+                            export cloudDeploy=${params.STACK_VERSION}
+                        fi
                         mvn clean -q -Dmaven.test.failure.ignore=true compile
                         mvn gatling:test -q -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
                     """


### PR DESCRIPTION
## Summary

Support "7.x" stack version as parameter, the value is hardcoded and should be updated with new minor release in place

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)