### PR TITLE
fix readFileToMap

### DIFF
--- a/src/test/resources/test/lastDeployment.txt
+++ b/src/test/resources/test/lastDeployment.txt
@@ -1,0 +1,5 @@
+deploymentId=asdkjqwr9cuw4j23k
+baseUrl=http://localhost:5620
+version=8.0.0
+branch=
+buildNumber=59211

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -89,6 +89,13 @@ object Helper {
   def readFileToMap(filePath: String): Map[String, Any] = {
     val lines: Iterator[String] =
       Source.fromFile(filePath).getLines().filter(str => str.trim.nonEmpty)
-    lines.map(str => (str.split("=")(0), str.split("=")(1))).toMap
+    lines
+      .map(str =>
+        (
+          str.split("=", 2)(0),
+          if (str.split("=", 2).length > 1) str.split("=", 2)(1) else ""
+        )
+      )
+      .toMap
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/scenario/Canvas.scala
+++ b/src/test/scala/org/kibanaLoadTest/scenario/Canvas.scala
@@ -5,8 +5,6 @@ import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 import org.kibanaLoadTest.helpers.Version
 
-import scala.concurrent.duration.DurationInt
-
 object Canvas {
   def loadWorkpad(
       baseUrl: String,
@@ -35,7 +33,7 @@ object Canvas {
             .headers(headers)
             .header("Referer", baseUrl + "/app/canvas")
             .check(status.is(200))
-        ).pause(5 seconds)
+        ).pause(5)
       }.exec(
           http("load workpad")
             .get("/api/canvas/workpad/${workpadId}")
@@ -44,7 +42,7 @@ object Canvas {
             .header("kbn-xsrf", "professionally-crafted-string-of-text")
             .check(status.is(200))
         )
-        .pause(1 seconds)
+        .pause(1)
         .exec(
           http("query canvas timelion")
             .post("/api/timelion/run")
@@ -55,7 +53,7 @@ object Canvas {
             .header("kbn-xsrf", "professionally-crafted-string-of-text")
             .check(status.is(200))
         )
-        .pause(1 seconds)
+        .pause(1)
         .exec(
           http("query canvas aggs 1")
             .post(fnsPath)
@@ -65,7 +63,7 @@ object Canvas {
             .header("Referer", baseUrl + "/app/canvas")
             .check(status.is(200))
         )
-        .pause(1 seconds)
+        .pause(1)
         .exec(
           http("query canvas aggs 2")
             .post(fnsPath)

--- a/src/test/scala/org/kibanaLoadTest/scenario/Dashboard.scala
+++ b/src/test/scala/org/kibanaLoadTest/scenario/Dashboard.scala
@@ -4,8 +4,6 @@ import io.gatling.core.Predef._
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 
-import scala.concurrent.duration.DurationInt
-
 object Dashboard {
   def load(baseUrl: String, headers: Map[String, String]): ChainBuilder =
     exec(
@@ -35,7 +33,7 @@ object Dashboard {
           .header("Referer", baseUrl + "/app/dashboards")
           .check(jsonPath("$.saved_objects[:1].id").saveAs("dashboardId"))
           .check(status.is(200))
-      ).pause(2 seconds)
+      ).pause(2)
         .exec(
           http("query panels list")
             .post("/api/saved_objects/_bulk_get")

--- a/src/test/scala/org/kibanaLoadTest/scenario/Discover.scala
+++ b/src/test/scala/org/kibanaLoadTest/scenario/Discover.scala
@@ -7,8 +7,6 @@ import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 import org.kibanaLoadTest.helpers.Helper
 
-import scala.concurrent.duration.DurationInt
-
 object Discover {
   private val discoverPayload =
     Helper.loadJsonString("data/discoverPayload.json")
@@ -36,7 +34,7 @@ object Discover {
         .body(StringBody(discoverPayloadQ1))
         .asJson
         .check(status.is(200))
-    ).pause(5 seconds)
+    ).pause(5)
       .exec(
         http("Discover query 2")
           .post("/internal/search/es")
@@ -46,7 +44,7 @@ object Discover {
           .asJson
           .check(status.is(200))
       )
-      .pause(5 seconds)
+      .pause(5)
       .exec(
         http("Discover query 3")
           .post("/internal/search/es")

--- a/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
@@ -3,7 +3,6 @@ package org.kibanaLoadTest.simulation
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
 import org.kibanaLoadTest.scenario.{Canvas, Dashboard, Discover, Login}
-import scala.concurrent.duration.DurationInt
 
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Kibana demo journey ${appConfig.buildVersion}"
@@ -25,11 +24,11 @@ class DemoJourney extends BaseSimulation {
   setUp(
     scn
       .inject(
-        constantConcurrentUsers(20) during (3 minutes), // 1
-        rampConcurrentUsers(20) to 50 during (3 minutes) // 2
+        constantConcurrentUsers(20) during (3 * 60), // 1
+        rampConcurrentUsers(20) to 50 during (3 * 60) // 2
       )
       .protocols(httpProtocol)
-  ).maxDuration(15 minutes)
+  ).maxDuration(15 * 60)
 
   // generate a closed workload injection profile
   // with levels of 10, 15, 20, 25 and 30 concurrent users

--- a/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
@@ -63,4 +63,24 @@ class HelpersTest {
       Helper.validateUrl(validUrl, "Smth went wrong")
     )
   }
+
+  @Test
+  def readFileToMapTest(): Unit = {
+    val data =
+      Helper.readFileToMap(
+        getClass.getResource("/test/lastDeployment.txt").getPath
+      )
+
+    assertEquals(
+      Map(
+        "branch" -> "",
+        "deploymentId" -> "asdkjqwr9cuw4j23k",
+        "version" -> "8.0.0",
+        "baseUrl" -> "http://localhost:5620",
+        "buildNumber" -> "59211"
+      ),
+      data
+    )
+  }
+
 }


### PR DESCRIPTION
## Summary

Allow `readFileToMap` to handle empty string values, small cleanup

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [x] Unit tests are added