### PR TITLE
fix timeout check in waitForClusterToStart

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -124,7 +124,6 @@ class CloudHttpClient {
   }
 
   def getInstanceStatus(deploymentId: String): Map[String, String] = {
-
     val jsonString = getDeploymentStateInfo(deploymentId)
     val items = Array("kibana", "elasticsearch", "apm")
 
@@ -198,5 +197,4 @@ class CloudHttpClient {
       s"deleteDeployment: Finished with status code ${response.getStatusLine.getStatusCode}"
     )
   }
-
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -18,14 +18,17 @@ class CloudHttpClient {
   private val httpClient = HttpClientBuilder.create.build
   private val deployPayloadTemplate = "cloudPayload/createDeployment.json"
   private val baseUrl = "https://staging.found.no/api/v1/deployments"
-  private val API_KEY = Option(System.getenv("API_KEY"))
-    .orElse(
-      throw new RuntimeException(
-        "API_KEY variable is required for new deployment"
-      )
-    )
-    .get
+  private val apiKey = Option(System.getenv("API_KEY"))
+
   val logger: Logger = LoggerFactory.getLogger("httpClient")
+
+  def getApiKey: String = {
+    if (this.apiKey.isEmpty) {
+      throw new RuntimeException(
+        "apiKey variable is required for new deployment"
+      )
+    } else this.apiKey.get
+  }
 
   def preparePayload(stackVersion: String, config: Config): String = {
     logger.info(
@@ -88,7 +91,7 @@ class CloudHttpClient {
   def createDeployment(payload: String): Map[String, String] = {
     logger.info(s"createDeployment: Creating new deployment")
     val createRequest = new HttpPost(baseUrl)
-    createRequest.addHeader("Authorization", s"ApiKey $API_KEY")
+    createRequest.addHeader("Authorization", s"ApiKey $getApiKey")
     createRequest.setEntity(new StringEntity(payload))
     val response = httpClient.execute(createRequest)
     val responseString = EntityUtils.toString(response.getEntity)
@@ -115,7 +118,7 @@ class CloudHttpClient {
 
   def getDeploymentStateInfo(id: String): String = {
     val getStateRequest: HttpGet = new HttpGet(s"$baseUrl/$id")
-    getStateRequest.addHeader("Authorization", s"ApiKey $API_KEY")
+    getStateRequest.addHeader("Authorization", s"ApiKey $getApiKey")
     val response = httpClient.execute(getStateRequest)
     EntityUtils.toString(response.getEntity)
   }
@@ -145,16 +148,21 @@ class CloudHttpClient {
     )
   }
 
-  def waitForClusterToStart(deploymentId: String): Unit = {
+  def waitForClusterToStart(
+      deploymentId: String,
+      fn: String => Map[String, String] = getInstanceStatus,
+      timeout: Int = DEPLOYMENT_READY_TIMOEOUT,
+      interval: Int = DEPLOYMENT_POLLING_INTERVAL
+  ): Unit = {
     var started = false
-    var waitTime: Int = DEPLOYMENT_READY_TIMOEOUT
-    var poolingInterval = DEPLOYMENT_POLLING_INTERVAL
+    var timeLeft = timeout
+    var poolingInterval = interval
     logger.info(
-      s"waitForClusterToStart: waitTime ${waitTime}ms, poolingInterval ${poolingInterval}ms"
+      s"waitForClusterToStart: waitTime ${timeout}ms, poolingInterval ${poolingInterval}ms"
     )
-    while (!started && poolingInterval > 0) {
+    while (!started && timeLeft > 0) {
       var statuses = Map.empty[String, String]
-      try statuses = getInstanceStatus(deploymentId)
+      try statuses = fn(deploymentId)
       catch {
         case ex: Exception =>
           logger.error(ex.getMessage)
@@ -163,18 +171,18 @@ class CloudHttpClient {
         logger.info(
           s"waitForClusterToStart: Deployment is in progress... ${statuses.toString()}"
         )
-        waitTime -= poolingInterval
+        timeLeft -= poolingInterval
         sleep(poolingInterval)
       } else {
-        logger.info(s"waitForClusterToStart: Deployment is ready!")
+        logger.info("waitForClusterToStart: Deployment is ready!")
         started = true
       }
     }
 
     if (!started)
-      throw new RuntimeException {
-        s"Deployment $deploymentId was not ready after $waitTime ms"
-      }
+      throw new RuntimeException(
+        s"Deployment $deploymentId was not ready after $timeout ms"
+      )
   }
 
   def deleteDeployment(id: String): Unit = {
@@ -182,7 +190,7 @@ class CloudHttpClient {
     val deleteRequest = new HttpPost(
       "%s/%s/_shutdown?hide=true&skip_snapshot=true".format(baseUrl, id)
     )
-    deleteRequest.addHeader("Authorization", s"ApiKey $API_KEY")
+    deleteRequest.addHeader("Authorization", s"ApiKey $getApiKey")
     val response = httpClient.execute(deleteRequest)
     logger.info(
       s"deleteDeployment: Finished with status code ${response.getStatusLine.getStatusCode}"

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -25,7 +25,7 @@ class CloudHttpClient {
   def getApiKey: String = {
     if (this.apiKey.isEmpty) {
       throw new RuntimeException(
-        "apiKey variable is required for new deployment"
+        "API_KEY variable is required to interact with Cloud service"
       )
     } else this.apiKey.get
   }

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -160,7 +160,7 @@ class CloudHttpClient {
       fn: String => Map[String, String] = getInstanceStatus,
       timeout: Int = DEPLOYMENT_READY_TIMOEOUT,
       interval: Int = DEPLOYMENT_POLLING_INTERVAL
-  ): Unit = {
+  ): Boolean = {
     var started = false
     var timeLeft = timeout
     var poolingInterval = interval
@@ -182,9 +182,9 @@ class CloudHttpClient {
     }
 
     if (!started)
-      throw new RuntimeException(
-        s"Deployment $deploymentId was not ready after $timeout ms"
-      )
+      logger.error(s"Deployment $deploymentId was not ready after $timeout ms")
+
+    started
   }
 
   def deleteDeployment(id: String): Unit = {

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -81,7 +81,11 @@ class BaseSimulation extends Simulation {
     val cloudClient = new CloudHttpClient
     val payload = cloudClient.preparePayload(stackVersion, config)
     val metadata = cloudClient.createDeployment(payload)
-    cloudClient.waitForClusterToStart(metadata("deploymentId"))
+    val isReady = cloudClient.waitForClusterToStart(metadata("deploymentId"))
+    if (!isReady) {
+      cloudClient.deleteDeployment(metadata("deploymentId"))
+      throw new RuntimeException("Stop due to failed deployment...")
+    }
     val host = cloudClient.getKibanaUrl(metadata("deploymentId"))
     val cloudConfig = ConfigFactory
       .load()

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -21,19 +21,19 @@ class CloudAPITest {
     cloudClient.deleteDeployment(metadata("deploymentId"))
   }
 
-  def getFakeStatus(id: String): Map[String, String] = {
-    // completely ignore id
-    Map(
-      "kibana" -> "initializing",
-      "elasticsearch" -> "started"
-    )
-  }
-
   @Test
   def waitForClusterToStartTest(): Unit = {
     val deploymentId = "fakeIt"
     val timeout = 100
     val interval = 20
+    def getFakeStatus(id: String): Map[String, String] = {
+      // completely ignore id
+      Map(
+        "kibana" -> "initializing",
+        "elasticsearch" -> "started"
+      )
+    }
+
     val exceptionThatWasThrown = assertThrows(
       classOf[RuntimeException],
       () => {

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -2,7 +2,7 @@ package org.kibanaLoadTest.test
 
 import org.junit.jupiter.api.Test
 import org.kibanaLoadTest.helpers.{CloudHttpClient, Helper}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 
 class CloudAPITest {
@@ -26,7 +26,7 @@ class CloudAPITest {
     val deploymentId = "fakeIt"
     val timeout = 100
     val interval = 20
-    def getFakeStatus(id: String): Map[String, String] = {
+    def getFailedStatus(id: String): Map[String, String] = {
       // completely ignore id
       Map(
         "kibana" -> "initializing",
@@ -34,23 +34,15 @@ class CloudAPITest {
       )
     }
 
-    val exceptionThatWasThrown = assertThrows(
-      classOf[RuntimeException],
-      () => {
-        val cloudClient = new CloudHttpClient
-        cloudClient.waitForClusterToStart(
-          deploymentId,
-          getFakeStatus,
-          timeout,
-          interval
-        )
-      }
+    val cloudClient = new CloudHttpClient
+    val isReady = cloudClient.waitForClusterToStart(
+      deploymentId,
+      getFailedStatus,
+      timeout,
+      interval
     )
 
-    assertEquals(
-      s"Deployment $deploymentId was not ready after $timeout ms",
-      exceptionThatWasThrown.getMessage
-    )
+    assertFalse(isReady)
   }
 
 }

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -44,5 +44,4 @@ class CloudAPITest {
 
     assertFalse(isReady)
   }
-
 }

--- a/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
@@ -82,5 +82,4 @@ class HelpersTest {
       data
     )
   }
-
 }


### PR DESCRIPTION
## Summary

Fix issue spotted by [jenkins](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/153/) run:
- timeout is ignored and job won't stop if deployment is unhealthy
- failed deployment is not deleted and remains after test run

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [x] Unit tests are added