### PR TITLE
[cloud] Support custom deployment config

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')
+        string(name: 'DEPLOY_CONFIG', defaultValue: 'config/deploy/default.conf', description: 'Path to Cloud deployment configuration')
     }
     stages {
         stage ('Initialize') {
@@ -55,12 +56,12 @@ pipeline {
                                 echo "Running tests against Kibana cloud instance"
                                 cd kibana-load-testing
                                 if [ "${params.STACK_VERSION}" = "7.x" ]; then
-                                    export cloudDeploy=${params.LATEST_7X}
+                                    ${env.CLOUD_VERSION} = ${params.LATEST_7X}
                                 else
-                                    export cloudDeploy=${params.STACK_VERSION}
+                                    ${env.CLOUD_VERSION} = ${params.STACK_VERSION}
                                 fi
                                 mvn clean -q -Dmaven.test.failure.ignore=true compile
-                                mvn gatling:test -q -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
+                                mvn gatling:test -q -DcloudStackVersion=${env.CLOUD_BUILD} -DdeploymentConfig=${params.DEPLOY_CONFIG} -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
                             """
                         }
                     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                         """
                     } else {
                         withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY') {
-                            sh """#!/bin/bash
+                            sh """
                                 echo "Running tests against Kibana cloud instance"
                                 cd kibana-load-testing
                                 mvn clean -q -Dmaven.test.failure.ignore=true compile

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,7 +4,6 @@ library 'kibana-pipeline-library'
 pipeline {
     agent { label 'docker && tests-xl-highmem' }
     parameters {
-        string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')
         string(name: 'DEPLOY_CONFIG', defaultValue: 'config/deploy/default.conf', description: 'Path to Cloud deployment configuration')
     }
@@ -13,7 +12,6 @@ pipeline {
             steps {
                 echo "PATH = ${PATH}"
                 echo "STACK_VERSION = ${params.STACK_VERSION}"
-                echo "LATEST_7X = ${params.LATEST_7X}"
                 echo "INGEST_RESULTS = ${params.INGEST_RESULTS}"
             }
         }
@@ -52,16 +50,11 @@ pipeline {
                         """
                     } else {
                         withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY') {
-                            sh """
+                            sh """#!/bin/bash
                                 echo "Running tests against Kibana cloud instance"
                                 cd kibana-load-testing
-                                if [ "${params.STACK_VERSION}" = "7.x" ]; then
-                                    ${env.CLOUD_VERSION} = ${params.LATEST_7X}
-                                else
-                                    ${env.CLOUD_VERSION} = ${params.STACK_VERSION}
-                                fi
                                 mvn clean -q -Dmaven.test.failure.ignore=true compile
-                                mvn gatling:test -q -DcloudStackVersion=${env.CLOUD_BUILD} -DdeploymentConfig=${params.DEPLOY_CONFIG} -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
+                                mvn gatling:test -q -DcloudStackVersion=${params.STACK_VERSION} -DdeploymentConfig=${params.DEPLOY_CONFIG} -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
                             """
                         }
                     }

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ mvn gatling:test -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJou
 ```
 mvn install
 export API_KEY=<your_cloud_key>
-export cloudDeploy=7.11.0-SNAPSHOT
-mvn gatling:test -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
+mvn gatling:test -q -DcloudStackVersion=7.11.0-SNAPSHOT -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
 ```
+- Optionally create a custom deployment configuration and pass it in command `-DdeploymentConfig=config/deploy/custom.conf`
+
+
 
 Follow logs to track deployment status:
 

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -78,6 +78,7 @@ class BaseSimulation extends Simulation {
   }
 
   def createDeployment(stackVersion: String): KibanaConfiguration = {
+    logger.info(s"Reading deployment configuration: $CLOUD_DEPLOY_CONFIG")
     val config = Helper.readResourceConfigFile(CLOUD_DEPLOY_CONFIG)
     val version = new Version(stackVersion)
     val providerName = if (version.isAbove79x) "cloud-basic" else "basic-cloud"

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -13,12 +13,15 @@ import java.nio.file.Paths
 
 class BaseSimulation extends Simulation {
   val logger: Logger = LoggerFactory.getLogger("Base Simulation")
-  val CLOUD_DEPLOY_CONFIG = "config/deploy/default.conf"
-  // "7.11.0-SNAPSHOT"
-  val cloudDeployVersion: Option[String] = Option(System.getenv("cloudDeploy"))
-  // "config/cloud-7.9.2.conf"
-  val envConfig: String =
-    Option(System.getenv("env")).getOrElse("config/local.conf")
+  // -DdeploymentConfig=path/to/config, default one deploys basic instance on GCP
+  val CLOUD_DEPLOY_CONFIG =
+    System.getProperty("deploymentConfig", "config/deploy/default.conf")
+  // -DcloudDeployVersion=8.0.0-SNAPSHOT, optional to deploy Cloud instance
+  val cloudDeployVersion: Option[String] = Option(
+    System.getProperty("cloudStackVersion")
+  )
+  // -DenvConfig=path/to/config, default is a local instance
+  val envConfig: String = System.getProperty("env", "config/local.conf")
 
   // appConfig is used to run load tests
   val appConfig: KibanaConfiguration = if (cloudDeployVersion.isDefined) {


### PR DESCRIPTION
## Summary

This PR allows to set custom deployment conf file with system variable: `-DeploymentConf=file/in/resources`:

```
14:07:12  Running tests against Kibana cloud instance
14:07:12  + cd kibana-load-testing
14:07:12  + mvn clean -q -Dmaven.test.failure.ignore=true compile
14:07:12  Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
14:07:27  + mvn gatling:test -q -DcloudStackVersion=8.0.0-SNAPSHOT -DdeploymentConfig=config/deploy/default.conf -Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/185/console)
- [ ] Unit tests are added