### PR TITLE
Change worker

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'kibana-pipeline-library'
 
 pipeline {
-    agent { label 'docker && tests-s' }
+    agent { label 'docker && debian-tests-s' }
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'kibana-pipeline-library'
 
 pipeline {
-    agent { label 'docker && oraclelinux-tests-s' }
+    agent { label 'docker && tests-s' }
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'kibana-pipeline-library'
 
 pipeline {
-    agent { label 'docker && ubuntu-tests-l' }
+    agent { label 'docker && oraclelinux-tests-s' }
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'kibana-pipeline-library'
 
 pipeline {
-    agent { label 'docker && debian-tests-s' }
+    agent { label 'docker && ubuntu-tests-l' }
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'kibana-pipeline-library'
 
 pipeline {
-    agent { label 'docker && tests-xl-highmem' }
+    agent { label 'docker && ubuntu-tests-l' }
     parameters {
         string(name: 'LATEST_7X', defaultValue: '7.12.0-SNAPSHOT', description: 'Latest 7.x snapshot')
         string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version on Cloud or user/kibana:branch to build from source code')

--- a/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
@@ -24,8 +24,10 @@ class DemoJourney extends BaseSimulation {
   setUp(
     scn
       .inject(
-        constantConcurrentUsers(20) during (3 * 60), // 1
-        rampConcurrentUsers(20) to 50 during (3 * 60) // 2
+        atOnceUsers(50)
+        // rampUsers(60).during(3 * 60)
+//        constantConcurrentUsers(20) during (3 * 60), // 1
+//        rampConcurrentUsers(20) to 100 during (3 * 60) // 2
       )
       .protocols(httpProtocol)
   ).maxDuration(15 * 60)

--- a/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
@@ -24,10 +24,8 @@ class DemoJourney extends BaseSimulation {
   setUp(
     scn
       .inject(
-        atOnceUsers(100)
-        // rampUsers(60).during(3 * 60)
-//        constantConcurrentUsers(20) during (3 * 60), // 1
-//        rampConcurrentUsers(20) to 100 during (3 * 60) // 2
+        constantConcurrentUsers(20) during (3 * 60), // 1
+        rampConcurrentUsers(20) to 50 during (3 * 60) // 2
       )
       .protocols(httpProtocol)
   ).maxDuration(15 * 60)

--- a/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/DemoJourney.scala
@@ -24,7 +24,7 @@ class DemoJourney extends BaseSimulation {
   setUp(
     scn
       .inject(
-        atOnceUsers(50)
+        atOnceUsers(100)
         // rampUsers(60).during(3 * 60)
 //        constantConcurrentUsers(20) during (3 * 60), // 1
 //        rampConcurrentUsers(20) to 100 during (3 * 60) // 2


### PR DESCRIPTION
## Summary

Turns out we can use a less power worker to run load testing on cloud or build kibana run tests against it on the same worker.
There is no significant time change, building kibana and running tests still takes around ~40 min; testing on cloud is ~ 11 min

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added