### PR TITLE
Add simulation for locally build Kibana

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                             echo "Prepare environment"
                             ./src/dev/ci_setup/setup.sh
                             echo "Build Kibana and run load scenario"
-                            ./test/scripts/jenkins_build_load_testing.sh
+                            ./test/scripts/jenkins_build_load_testing.sh -s 'local.AllAtOnceJourney'
                         """
                     } else {
                         withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY') {

--- a/src/test/scala/org/kibanaLoadTest/KibanaConfiguration.scala
+++ b/src/test/scala/org/kibanaLoadTest/KibanaConfiguration.scala
@@ -4,9 +4,9 @@ import com.typesafe.config._
 import org.kibanaLoadTest.helpers.{Helper, HttpHelper, Version}
 import org.slf4j.{Logger, LoggerFactory}
 import spray.json.DefaultJsonProtocol.{
-  IntJsonFormat,
-  StringJsonFormat,
-  BooleanJsonFormat
+  BooleanJsonFormat,
+  LongJsonFormat,
+  StringJsonFormat
 }
 import spray.json.lenses.JsonLenses._
 
@@ -24,7 +24,7 @@ class KibanaConfiguration {
   var isAbove79x = true
   var deploymentId: Option[String] = None
   var buildHash = ""
-  var buildNumber = 0
+  var buildNumber: Long = 0
   var isSnapshotBuild = false
   var branchName: Option[String] = None
 
@@ -89,7 +89,7 @@ class KibanaConfiguration {
     this.buildHash =
       response.extract[String](Symbol("version") / Symbol("build_hash"))
     this.buildNumber =
-      response.extract[Int](Symbol("version") / Symbol("build_number"))
+      response.extract[Long](Symbol("version") / Symbol("build_number"))
     this.isSnapshotBuild = response
       .extract[Boolean](Symbol("version") / Symbol("build_snapshot"))
     this.version =

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -2,6 +2,7 @@ package org.kibanaLoadTest.simulation
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 import io.gatling.http.protocol.HttpProtocolBuilder
 import org.kibanaLoadTest.KibanaConfiguration
@@ -15,7 +16,7 @@ import java.nio.file.Paths
 class BaseSimulation extends Simulation {
   val logger: Logger = LoggerFactory.getLogger("Base Simulation")
   // -DdeploymentConfig=path/to/config, default one deploys basic instance on GCP
-  val CLOUD_DEPLOY_CONFIG =
+  val CLOUD_DEPLOY_CONFIG: String =
     System.getProperty("deploymentConfig", "config/deploy/default.conf")
   // -DcloudDeployVersion=8.0.0-SNAPSHOT, optional to deploy Cloud instance
   val cloudDeployVersion: Option[String] = Option(
@@ -163,7 +164,7 @@ class BaseSimulation extends Simulation {
 
   var defaultTextHeaders = Map("Content-Type" -> "text/html; charset=utf-8")
 
-  var loginStep = Login
+  var loginStep: ChainBuilder = Login
     .doLogin(
       appConfig.isSecurityEnabled,
       appConfig.loginPayload,

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -1,14 +1,14 @@
 package org.kibanaLoadTest.simulation.local
 
+import org.kibanaLoadTest.simulation.BaseSimulation
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
 import org.kibanaLoadTest.scenario.{Canvas, Dashboard, Discover}
-import org.kibanaLoadTest.simulation.BaseSimulation
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
-class CloudAtOnceJourney extends BaseSimulation {
+class AllAtOnceJourney extends BaseSimulation {
   def scenarioName(module: String): String = {
     s"Cloud  atOnce ${module} ${appConfig.buildVersion}"
   }
@@ -52,5 +52,4 @@ class CloudAtOnceJourney extends BaseSimulation {
           .andThen(scnCanvas.inject(atOnceUsers(120)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
-
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -1,0 +1,56 @@
+package org.kibanaLoadTest.simulation.local
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ScenarioBuilder
+import org.kibanaLoadTest.scenario.{Canvas, Dashboard, Discover}
+import org.kibanaLoadTest.simulation.BaseSimulation
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+class CloudAtOnceJourney extends BaseSimulation {
+  def scenarioName(module: String): String = {
+    s"Cloud  atOnce ${module} ${appConfig.buildVersion}"
+  }
+
+  val simulationTimeout =
+    FiniteDuration(
+      10,
+      TimeUnit.MINUTES
+    )
+
+  val loginPause =
+    FiniteDuration(
+      2,
+      TimeUnit.SECONDS
+    )
+
+  val scnPause =
+    FiniteDuration(
+      20,
+      TimeUnit.SECONDS
+    )
+
+  val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
+    .exec(loginStep.pause(loginPause))
+    .exec(Discover.doQuery(appConfig.baseUrl, defaultHeaders))
+
+  val scnDashboard: ScenarioBuilder = scenario(scenarioName("dashboard"))
+    .exec(loginStep.pause(loginPause))
+    .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders))
+
+  val scnCanvas: ScenarioBuilder = scenario(scenarioName("canvas"))
+    .exec(loginStep.pause(loginPause))
+    .exec(Canvas.loadWorkpad(appConfig.baseUrl, defaultHeaders))
+
+  setUp(
+    scnDiscover
+      .inject(atOnceUsers(120), nothingFor(scnPause))
+      .andThen(
+        scnDashboard
+          .inject(atOnceUsers(120), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(120)))
+      )
+  ).protocols(httpProtocol).maxDuration(simulationTimeout)
+
+}

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -45,11 +45,11 @@ class AllAtOnceJourney extends BaseSimulation {
 
   setUp(
     scnDiscover
-      .inject(atOnceUsers(300), nothingFor(scnPause))
+      .inject(atOnceUsers(400), nothingFor(scnPause))
       .andThen(
         scnDashboard
-          .inject(atOnceUsers(300), nothingFor(scnPause))
-          .andThen(scnCanvas.inject(atOnceUsers(300)))
+          .inject(atOnceUsers(400), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(400)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -45,11 +45,11 @@ class AllAtOnceJourney extends BaseSimulation {
 
   setUp(
     scnDiscover
-      .inject(atOnceUsers(120), nothingFor(scnPause))
+      .inject(atOnceUsers(150), nothingFor(scnPause))
       .andThen(
         scnDashboard
-          .inject(atOnceUsers(120), nothingFor(scnPause))
-          .andThen(scnCanvas.inject(atOnceUsers(120)))
+          .inject(atOnceUsers(150), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(150)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -45,11 +45,11 @@ class AllAtOnceJourney extends BaseSimulation {
 
   setUp(
     scnDiscover
-      .inject(atOnceUsers(250), nothingFor(scnPause))
+      .inject(atOnceUsers(300), nothingFor(scnPause))
       .andThen(
         scnDashboard
-          .inject(atOnceUsers(250), nothingFor(scnPause))
-          .andThen(scnCanvas.inject(atOnceUsers(250)))
+          .inject(atOnceUsers(300), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(300)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -45,11 +45,11 @@ class AllAtOnceJourney extends BaseSimulation {
 
   setUp(
     scnDiscover
-      .inject(atOnceUsers(150), nothingFor(scnPause))
+      .inject(atOnceUsers(200), nothingFor(scnPause))
       .andThen(
         scnDashboard
-          .inject(atOnceUsers(150), nothingFor(scnPause))
-          .andThen(scnCanvas.inject(atOnceUsers(150)))
+          .inject(atOnceUsers(200), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(200)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/local/AllAtOnceJourney.scala
@@ -45,11 +45,11 @@ class AllAtOnceJourney extends BaseSimulation {
 
   setUp(
     scnDiscover
-      .inject(atOnceUsers(200), nothingFor(scnPause))
+      .inject(atOnceUsers(250), nothingFor(scnPause))
       .andThen(
         scnDashboard
-          .inject(atOnceUsers(200), nothingFor(scnPause))
-          .andThen(scnCanvas.inject(atOnceUsers(200)))
+          .inject(atOnceUsers(250), nothingFor(scnPause))
+          .andThen(scnCanvas.inject(atOnceUsers(250)))
       )
   ).protocols(httpProtocol).maxDuration(simulationTimeout)
 }


### PR DESCRIPTION
## Summary

atOnce 120:
```
Global Information --------------------------------------------------------
> request count                                       2280 (OK=2280   KO=0     )
> min response time                                     18 (OK=18     KO=-     )
> max response time                                  17050 (OK=17050  KO=-     )
> mean response time                                  3296 (OK=3296   KO=-     )
> std deviation                                       3721 (OK=3721   KO=-     )
> response time 50th percentile                       1824 (OK=1824   KO=-     )
> response time 75th percentile                       5188 (OK=5188   KO=-     )
> response time 95th percentile                      13703 (OK=13703  KO=-     )
> response time 99th percentile                      16390 (OK=16390  KO=-     )
> mean requests/sec                                 24.255 (OK=24.255 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           469 ( 21%)
> 800 ms < t < 1200 ms                                 504 ( 22%)
> t > 1200 ms                                         1307 ( 57%)
> failed                                                 0 (  0%)
```

atOnce 150:
```
Global Information --------------------------------------------------------
> request count                                       2850 (OK=2850   KO=0     )
> min response time                                     15 (OK=15     KO=-     )
> max response time                                  15394 (OK=15394  KO=-     )
> mean response time                                  3160 (OK=3160   KO=-     )
> std deviation                                       3437 (OK=3437   KO=-     )
> response time 50th percentile                       1836 (OK=1836   KO=-     )
> response time 75th percentile                       4597 (OK=4597   KO=-     )
> response time 95th percentile                      10983 (OK=10983  KO=-     )
> response time 99th percentile                      14798 (OK=14798  KO=-     )
> mean requests/sec                                 30.978 (OK=30.978 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           586 ( 21%)
> 800 ms < t < 1200 ms                                 591 ( 21%)
> t > 1200 ms                                         1673 ( 59%)
> failed                                                 0 (  0%)
```

atOnce 200
```
Global Information --------------------------------------------------------
> request count                                       3800 (OK=3800   KO=0     )
> min response time                                     16 (OK=16     KO=-     )
> max response time                                  21987 (OK=21987  KO=-     )
> mean response time                                  4214 (OK=4214   KO=-     )
> std deviation                                       4740 (OK=4740   KO=-     )
> response time 50th percentile                       1910 (OK=1910   KO=-     )
> response time 75th percentile                       5405 (OK=5405   KO=-     )
> response time 95th percentile                      14532 (OK=14532  KO=-     )
> response time 99th percentile                      21110 (OK=21110  KO=-     )
> mean requests/sec                                 33.333 (OK=33.333 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           549 ( 14%)
> 800 ms < t < 1200 ms                                 459 ( 12%)
> t > 1200 ms                                         2792 ( 73%)
> failed                                                 0 (  0%)
```

atOnce 250
```
Global Information --------------------------------------------------------
> request count                                       4750 (OK=4750   KO=0     )
> min response time                                     45 (OK=45     KO=-     )
> max response time                                  29101 (OK=29101  KO=-     )
> mean response time                                  5929 (OK=5929   KO=-     )
> std deviation                                       6916 (OK=6916   KO=-     )
> response time 50th percentile                       2134 (OK=2134   KO=-     )
> response time 75th percentile                       7559 (OK=7559   KO=-     )
> response time 95th percentile                      28112 (OK=28112  KO=-     )
> response time 99th percentile                      28910 (OK=28910  KO=-     )
> mean requests/sec                                 32.095 (OK=32.095 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           376 (  8%)
> 800 ms < t < 1200 ms                                 288 (  6%)
> t > 1200 ms                                         4086 ( 86%)
> failed                                                 0 (  0%)
```

atOnce 300
```
Global Information --------------------------------------------------------
> request count                                       5700 (OK=5700   KO=0     )
> min response time                                     38 (OK=38     KO=-     )
> max response time                                  29295 (OK=29295  KO=-     )
> mean response time                                  5702 (OK=5702   KO=-     )
> std deviation                                       6389 (OK=6389   KO=-     )
> response time 50th percentile                       2784 (OK=2784   KO=-     )
> response time 75th percentile                       7662 (OK=7662   KO=-     )
> response time 95th percentile                      17530 (OK=17530  KO=-     )
> response time 99th percentile                      28115 (OK=28115  KO=-     )
> mean requests/sec                                 38.255 (OK=38.255 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           588 ( 10%)
> 800 ms < t < 1200 ms                                 429 (  8%)
> t > 1200 ms                                         4683 ( 82%)
> failed                                                 0 (  0%)
```

atOnce 400
```
Global Information --------------------------------------------------------
> request count                                       7600 (OK=7600   KO=0     )
> min response time                                     48 (OK=48     KO=-     )
> max response time                                  43829 (OK=43829  KO=-     )
> mean response time                                  9299 (OK=9299   KO=-     )
> std deviation                                      10777 (OK=10777  KO=-     )
> response time 50th percentile                       3634 (OK=3634   KO=-     )
> response time 75th percentile                      12458 (OK=12458  KO=-     )
> response time 95th percentile                      33946 (OK=33946  KO=-     )
> response time 99th percentile                      43077 (OK=43077  KO=-     )
> mean requests/sec                                 34.862 (OK=34.862 KO=-     )
Response Time Distribution ------------------------------------------------
> t < 800 ms                                           249 (  3%)
> 800 ms < t < 1200 ms                                 332 (  4%)
> t > 1200 ms                                         7019 ( 92%)
> failed                                                 0 (  0%)
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added