### PR TITLE
ingest more data to build stats

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
@@ -22,7 +22,11 @@ class ESWrapper(config: ESConfiguration) {
   val logger: Logger = LoggerFactory.getLogger("ES_Client")
   val indexName = "gatling-data"
 
-  def ingest(logFilePath: String, metaFilePath: String): Unit = {
+  def ingest(
+      logFilePath: String,
+      metaFilePath: String,
+      extras: Map[String, Any]
+  ): Unit = {
     if (!Files.exists(Paths.get(logFilePath))) {
       throw new RuntimeException(
         s"Gatling report file '$logFilePath' is not found"
@@ -86,7 +90,11 @@ class ESWrapper(config: ESConfiguration) {
           | "isSnapshotBuild": ${meta("isSnapshotBuild")},
           | "baseUrl": "${meta("baseUrl")}",
           | "scenario": "$simulationClass",
-          | "maxUsers": ${meta("maxUsers")}
+          | "maxUsers": ${meta("maxUsers")},
+          | "deploymentId": ${meta("deploymentId")},
+          | "isCloudDeployment": ${meta("isCloudDeployment")},
+          | "CI_BUILD_ID": "${extras("buildId")}",
+          | "CI_RUN_URL": "${extras("runUrl")}"
           |}
       """.stripMargin
 

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
@@ -94,7 +94,7 @@ class ESWrapper(config: ESConfiguration) {
           | "deploymentId": "${meta("deploymentId")}",
           | "isCloudDeployment": ${meta("isCloudDeployment")},
           | "CI_BUILD_ID": "${extras("buildId")}",
-          | "CI_RUN_URL": "${extras("runUrl")}"
+          | "CI_BUILD_URL": "${extras("buildUrl")}"
           |}
       """.stripMargin
 

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
@@ -91,7 +91,7 @@ class ESWrapper(config: ESConfiguration) {
           | "baseUrl": "${meta("baseUrl")}",
           | "scenario": "$simulationClass",
           | "maxUsers": ${meta("maxUsers")},
-          | "deploymentId": ${meta("deploymentId")},
+          | "deploymentId": "${meta("deploymentId")}",
           | "isCloudDeployment": ${meta("isCloudDeployment")},
           | "CI_BUILD_ID": "${extras("buildId")}",
           | "CI_RUN_URL": "${extras("runUrl")}"

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -120,7 +120,7 @@ object Helper {
   def getCIMeta: Map[String, String] = {
     Map(
       "buildId" -> Option(System.getenv("BUILD_ID")).getOrElse(""),
-      "runUrl" -> Option(System.getenv("CI_RUN_URL")).getOrElse("")
+      "buildUrl" -> Option(System.getenv("BUILD_URL")).getOrElse("")
     )
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -9,7 +9,6 @@ import java.time.format.DateTimeFormatter
 import java.util.{Calendar, Date, TimeZone}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.{Logger, LoggerFactory}
-
 import scala.io.Source
 
 object Helper {
@@ -116,5 +115,12 @@ object Helper {
         )
       )
       .toMap
+  }
+
+  def getCIMeta: Map[String, String] = {
+    Map(
+      "buildId" -> Option(System.getenv("BUILD_ID")).getOrElse(""),
+      "runUrl" -> Option(System.getenv("CI_RUN_URL")).getOrElse("")
+    )
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
@@ -68,6 +68,8 @@ object SimulationHelper {
       "deploymentId" -> (if (config.deploymentId.isDefined)
                            config.deploymentId.get
                          else ""),
+      "isCloudDeployment" -> (if (config.deploymentId.isDefined) true
+                              else false),
       "baseUrl" -> config.baseUrl,
       "buildHash" -> config.buildHash,
       "buildNumber" -> config.buildNumber,

--- a/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
@@ -68,8 +68,7 @@ object SimulationHelper {
       "deploymentId" -> (if (config.deploymentId.isDefined)
                            config.deploymentId.get
                          else ""),
-      "isCloudDeployment" -> (if (config.deploymentId.isDefined) true
-                              else false),
+      "isCloudDeployment" -> config.deploymentId.isDefined,
       "baseUrl" -> config.baseUrl,
       "buildHash" -> config.buildHash,
       "buildNumber" -> config.buildNumber,

--- a/src/test/scala/org/kibanaLoadTest/ingest/Main.scala
+++ b/src/test/scala/org/kibanaLoadTest/ingest/Main.scala
@@ -3,7 +3,7 @@ package org.kibanaLoadTest.ingest
 import java.io.File
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.kibanaLoadTest.ESConfiguration
-import org.kibanaLoadTest.helpers.ESWrapper
+import org.kibanaLoadTest.helpers.{ESWrapper, Helper}
 import org.kibanaLoadTest.helpers.Helper.{getReportFolderPaths, getTargetPath}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -29,10 +29,11 @@ object Main {
       getTargetPath + File.separator + "lastDeployment.txt"
     val simulationFiles =
       getReportFolderPaths.map(_ + File.separator + "simulation.log")
+    val ciMeta = Helper.getCIMeta
 
     logger.info(s"Found ${simulationFiles.length} report folders")
     simulationFiles.foreach(file =>
-      esClient.ingest(file, lastDeploymentFilePath)
+      esClient.ingest(file, lastDeploymentFilePath, ciMeta)
     )
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -82,6 +82,9 @@ class BaseSimulation extends Simulation {
     logger.info(
       s"Running ${getClass.getSimpleName} simulation with ${props.maxUsers} users"
     )
+    val ci = Helper.getCIMeta
+    println("buildId=" + ci("buildId"))
+    println("runUrl=" + ci("runUrl"))
     appConfig.print()
     // saving deployment info to target/lastDeployment.txt"
     SimulationHelper.saveDeploymentMeta(appConfig, props.maxUsers)

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -82,9 +82,6 @@ class BaseSimulation extends Simulation {
     logger.info(
       s"Running ${getClass.getSimpleName} simulation with ${props.maxUsers} users"
     )
-    val ci = Helper.getCIMeta
-    println("buildId=" + ci("buildId"))
-    println("runUrl=" + ci("runUrl"))
     appConfig.print()
     // saving deployment info to target/lastDeployment.txt"
     SimulationHelper.saveDeploymentMeta(appConfig, props.maxUsers)

--- a/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
@@ -59,7 +59,8 @@ class IngestionTest {
     val logFilePath = getLastReportPath + File.separator + "simulation.log"
     val lastDeploymentFilePath =
       getTargetPath + File.separator + "lastDeployment.txt"
-    esClient.ingest(logFilePath, lastDeploymentFilePath)
+    val ciMeta = Helper.getCIMeta
+    esClient.ingest(logFilePath, lastDeploymentFilePath, ciMeta)
   }
 
   @Test


### PR DESCRIPTION
## Summary

ingest deploymentId, CI_BUILD_ID, CI_RUN_URL in order to filter/search data

```
"_source": {
    "timestamp": "2021-02-02T15:47:14.419Z",
    "name": "query gauge data",
    "requestSendStartTime": "2021-02-02T15:45:49.172Z",
    "responseReceiveEndTime": "2021-02-02T15:46:01.188Z",
    "status": "OK",
    "requestTime": 12016,
    "message": "",
    "version": "8.0.0",
    "buildHash": "fb19aab307fb80740b60fbd4a0861e75380e96f9",
    "buildNumber": 40008,
    "branch": "",
    "isSnapshotBuild": true,
    "baseUrl": "https://f4c2dd26df52441a8e9804d861dae720.us-central1.gcp.foundit.no:9243",
    "scenario": "org.kibanaLoadTest.simulation.cloud.AtOnceJourney",
    "maxUsers": 80,
    "deploymentId": "4fc29576b274488788eab2b3f8e61776",
    "isCloudDeployment": true,
    "CI_BUILD_ID": "261",
    "CI_BUILD_URL": "https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/261/"
  },
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added