### PR TITLE
[cloud] save host and creds to file

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -145,13 +145,20 @@ class CloudHttpClient {
       .toMap
   }
 
-  def getKibanaUrl(deploymentId: String): String = {
+  def getServiceUrl(
+      deploymentId: String,
+      resources: Array[String]
+  ): Map[String, String] = {
     val jsonString = getDeploymentStateInfo(deploymentId)
-    jsonString.extract[String](
-      Symbol("resources") / Symbol("kibana") / element(0) / Symbol(
-        "info"
-      ) / Symbol("metadata") / Symbol("service_url")
-    )
+    resources
+      .map(resource => {
+        resource -> jsonString.extract[String](
+          Symbol("resources") / Symbol(resource) / element(0) / Symbol(
+            "info"
+          ) / Symbol("metadata") / Symbol("service_url")
+        )
+      })
+      .toMap
   }
 
   def waitForClusterToStart(

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -1,6 +1,6 @@
 package org.kibanaLoadTest.helpers
 
-import java.io.{File, PrintWriter}
+import java.io.{File, FileWriter, PrintWriter}
 import java.net.{MalformedURLException, URL}
 import java.nio.file.Paths
 import java.text.SimpleDateFormat
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter
 import java.util.{Calendar, Date, TimeZone}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.{Logger, LoggerFactory}
+
 import scala.io.Source
 
 object Helper {
@@ -125,5 +126,13 @@ object Helper {
         .getOrElse(""),
       "branchName" -> Option(System.getenv("branch_specifier")).getOrElse("")
     )
+  }
+
+  def writeFile(fileName: String, lines: Array[String]): Unit = {
+    val fw = new FileWriter(fileName)
+    for (i <- 0 to lines.length - 1) {
+      fw.write(lines(i))
+    }
+    fw.close()
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -16,7 +16,10 @@ class CloudAPITest {
     val metadata = cloudClient.createDeployment(payload)
     assertEquals(metadata.size, 3, "metadata size is incorrect")
     cloudClient.waitForClusterToStart(metadata("deploymentId"))
-    val host = cloudClient.getKibanaUrl(metadata("deploymentId"))
+    val host =
+      cloudClient.getServiceUrl(metadata("deploymentId"), Array("kibana"))(
+        "kibana"
+      )
     assertTrue(host.startsWith("https://"), "Kibana Url is incorrect")
     cloudClient.deleteDeployment(metadata("deploymentId"))
   }

--- a/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
@@ -98,4 +98,11 @@ class HelpersTest {
     val paths = Helper.getReportFolderPaths
     assertEquals(2, paths.length)
   }
+
+  @Test
+  def writeFileTest(): Unit = {
+    Helper.writeFile("test.sh", Array("line1\n", "line2\n"))
+    val f = new File("test.sh")
+    assertEquals(true, f.exists())
+  }
 }


### PR DESCRIPTION
## Summary

To enable monitoring for cloud instance we need to know hosts and credentials. This PR writes it to bash script that we can use to apply values

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added