### PR TITLE
[lang] switch to scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <scala.version>2.13.5</scala.version>
+        <scala.version>2.12.1</scala.version>
         <encoding>UTF-8</encoding>
-
-        <gatling.version>3.5.1</gatling.version>
+        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+        <gatling.version>3.4.2</gatling.version>
         <gatling-maven-plugin.version>3.1.2</gatling-maven-plugin.version>
     </properties>
 
@@ -63,23 +63,18 @@
         </dependency>
         <dependency>
             <groupId>io.spray</groupId>
-            <artifactId>spray-json_2.13</artifactId>
-            <version>1.3.6</version>
+            <artifactId>spray-json_2.12</artifactId>
+            <version>1.3.3</version>
         </dependency>
         <dependency>
             <groupId>net.virtual-void</groupId>
-            <artifactId>json-lenses_2.13</artifactId>
+            <artifactId>json-lenses_2.12</artifactId>
             <version>0.6.2</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.13</artifactId>
+            <artifactId>scala-logging_2.12</artifactId>
             <version>3.9.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parallel-collections_2.13</artifactId>
-            <version>1.0.1</version>
         </dependency>
     </dependencies>
 
@@ -102,14 +97,13 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.4.1</version>
+                <version>${scala-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <recompileMode>all</recompileMode>
                             <jvmArgs>
                                 <jvmArg>-Xss100M</jvmArg>
                             </jvmArgs>

--- a/src/test/scala/Engine.scala
+++ b/src/test/scala/Engine.scala
@@ -2,9 +2,8 @@ import io.gatling.app.Gatling
 import io.gatling.core.config.GatlingPropertiesBuilder
 
 object Engine extends App {
-
   val props = new GatlingPropertiesBuilder()
-    .resourcesDirectory(IDEPathHelper.resourcesDirectory.toString)
+    .resourcesDirectory(IDEPathHelper.mavenResourcesDirectory.toString)
     .resultsDirectory(IDEPathHelper.resultsDirectory.toString)
     .binariesDirectory(IDEPathHelper.mavenBinariesDirectory.toString)
 

--- a/src/test/scala/IDEPathHelper.scala
+++ b/src/test/scala/IDEPathHelper.scala
@@ -1,6 +1,6 @@
-import java.nio.file.{Path, Paths}
+import io.gatling.commons.util.PathHelper.RichPath
 
-import io.gatling.commons.shared.unstable.util.PathHelper._
+import java.nio.file.{Path, Paths}
 
 object IDEPathHelper {
 

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESWrapper.scala
@@ -16,7 +16,6 @@ import org.elasticsearch.client.{
 import org.elasticsearch.common.xcontent.XContentType
 import org.kibanaLoadTest.ESConfiguration
 import org.slf4j.{Logger, LoggerFactory}
-import scala.collection.parallel.CollectionConverters._
 
 class ESWrapper(config: ESConfiguration) {
   val logger: Logger = LoggerFactory.getLogger("ES_Client")


### PR DESCRIPTION
## Summary

PR downgrades Scala version in order to meet Gatling requirements:

`Since 3.0, Gatling requires Scala 2.12. Gatling is not compatible with Scala 2.11 nor Scala 2.13.`
[source](https://gatling.io/docs/current/installation/)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added