### PR TITLE
adding class to stop deployments

### DIFF
--- a/src/test/resources/cloudPayload/searchDeployments.json
+++ b/src/test/resources/cloudPayload/searchDeployments.json
@@ -1,0 +1,25 @@
+{
+  "size":150,
+  "query":{
+    "bool":{
+      "must":[
+        {
+          "nested":{
+            "path":"resources.elasticsearch",
+            "query":{
+              "exists":{
+                "field":"resources.elasticsearch.id"
+              }
+            }
+          }
+        }
+      ],
+      "must_not":[
+
+      ],
+      "filter":[
+
+      ]
+    }
+  }
+}

--- a/src/test/scala/org/kibanaLoadTest/deploy/DeleteAll.scala
+++ b/src/test/scala/org/kibanaLoadTest/deploy/DeleteAll.scala
@@ -1,0 +1,56 @@
+package org.kibanaLoadTest.deploy
+
+import org.kibanaLoadTest.helpers.CloudHttpClient
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.immutable.{AbstractMap, SeqMap, SortedMap}
+
+object DeleteAll {
+  object Scope extends Enumeration {
+    val ALL = Value("all")
+    val TEST = Value("test")
+  }
+  val logger: Logger = LoggerFactory.getLogger("deploy:DeleteAll")
+
+  def main(args: Array[String]): Unit = {
+    val scope = Scope.withName(System.getProperty("scope", "test"))
+    var cleanItems = collection.mutable.Map[String, String]()
+
+    val cloudClient = new CloudHttpClient
+    val deployments = cloudClient.getDeployments
+    logger.info(s"Found ${deployments.size} running deployments")
+    if (scope == Scope.ALL) {
+      logger.info(s"Deleting all deployments")
+      cleanItems.addAll(deployments)
+    } else {
+      logger.info(s"Deleting only 'load-testing' deployments")
+      deployments.foreach {
+        case (name, id) => {
+          if (name.startsWith("load-testing")) {
+            cleanItems += name -> id
+          }
+        }
+      }
+    }
+
+    logger.info(s"Got ${cleanItems.size} deployments to delete")
+    if (!cleanItems.isEmpty) {
+      cleanItems.foreach {
+        case (name, id) =>
+          cloudClient.deleteDeployment(id)
+          Thread.sleep(2 * 1000)
+      }
+      // wait a bit for deployments to be deleted
+      logger.info(s"Waiting...")
+      Thread.sleep(20 * 1000)
+      // checking running deployments again
+      val deploymentsAfter = cloudClient.getDeployments
+      logger.info(s"Found ${deploymentsAfter.size} deployments after cleanup")
+      if (deploymentsAfter.nonEmpty) {
+        deploymentsAfter.foreach {
+          case (name, id) => logger.info(s"name: $name, id: $id")
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudEnv.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudEnv.scala
@@ -1,0 +1,6 @@
+package org.kibanaLoadTest.helpers
+
+object CloudEnv extends Enumeration {
+  val STAGING = Value("staging")
+  val PROD = Value("prod")
+}

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -16,7 +16,7 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import com.typesafe.config.ConfigValueType
 
-class CloudHttpClient(var env: String = "staging") {
+class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
   private val DEPLOYMENT_READY_TIMEOUT = 7 * 60 * 1000 // 7 min
   private val DEPLOYMENT_POLLING_INTERVAL = 30 * 1000 // 20 sec
   private val CONNECT_TIMEOUT = 30000
@@ -29,7 +29,7 @@ class CloudHttpClient(var env: String = "staging") {
   private val deployPayloadTemplate = "cloudPayload/createDeployment.json"
   private val searchDeploymentsTemplate = "cloudPayload/searchDeployments.json"
   private val apiKey = Option(System.getenv("API_KEY"))
-  private val baseUrl = if (env == "prod") PROD_URL else STAGING_URL
+  private val baseUrl = if (env == CloudEnv.PROD) PROD_URL else STAGING_URL
 
   val logger: Logger = LoggerFactory.getLogger("httpClient")
 

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -35,6 +35,8 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
 
   case class CloudResponse(statusCode: Int, reason: String, jsonString: String)
 
+  def getEnv: CloudEnv.Value = env
+
   def httpBase(
       fx: CloseableHttpClient => CloseableHttpResponse
   ): Option[CloudResponse] = {

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -16,17 +16,20 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import com.typesafe.config.ConfigValueType
 
-class CloudHttpClient {
-  private val DEPLOYMENT_READY_TIMOEOUT = 7 * 60 * 1000 // 7 min
+class CloudHttpClient(var env: String = "staging") {
+  private val DEPLOYMENT_READY_TIMEOUT = 7 * 60 * 1000 // 7 min
   private val DEPLOYMENT_POLLING_INTERVAL = 30 * 1000 // 20 sec
   private val CONNECT_TIMEOUT = 30000
   private val CONNECTION_REQUEST_TIMEOUT = 60000
   private val SOCKET_TIMEOUT = 60000
   private val MSG_NO_RESPONSE =
     "Failed to create new deployment, response is not a JSON"
+  private val STAGING_URL = "https://staging.found.no/api/v1"
+  private val PROD_URL = "https://cloud.elastic.co/api/v1"
   private val deployPayloadTemplate = "cloudPayload/createDeployment.json"
-  private val baseUrl = "https://staging.found.no/api/v1/deployments"
+  private val searchDeploymentsTemplate = "cloudPayload/searchDeployments.json"
   private val apiKey = Option(System.getenv("API_KEY"))
+  private val baseUrl = if (env == "prod") PROD_URL else STAGING_URL
 
   val logger: Logger = LoggerFactory.getLogger("httpClient")
 
@@ -192,7 +195,7 @@ class CloudHttpClient {
 
   def createDeployment(payload: String): Map[String, String] = {
     logger.info(s"createDeployment: Creating new deployment")
-    val response = httpPost("?validate_only=false", payload)
+    val response = httpPost("/deployments?validate_only=false", payload)
     if (response.isDefined)
       logger.info(
         s"createDeployment: Request completed with `${response.get.reason} ${response.get.statusCode}`"
@@ -228,7 +231,7 @@ class CloudHttpClient {
 
   def getDeploymentStateInfo(id: String): String = {
     val response = httpGet(
-      s"/$id?enrich_with_template=false&show_metadata=false&show_plans=false"
+      s"/deployments/$id?enrich_with_template=false&show_metadata=false&show_plans=false"
     )
     if (response.isEmpty) throw new RuntimeException(MSG_NO_RESPONSE)
     response.get.jsonString
@@ -281,7 +284,7 @@ class CloudHttpClient {
   def waitForClusterToStart(
       deploymentId: String,
       fn: String => Map[String, String] = getInstanceStatus,
-      timeout: Int = DEPLOYMENT_READY_TIMOEOUT,
+      timeout: Int = DEPLOYMENT_READY_TIMEOUT,
       interval: Int = DEPLOYMENT_POLLING_INTERVAL
   ): Boolean = {
     var started = false
@@ -312,7 +315,9 @@ class CloudHttpClient {
 
   def deleteDeployment(id: String): Unit = {
     logger.info(s"deleteDeployment: Deployment $id")
-    val response = httpPost(s"/$id/_shutdown?hide=true&skip_snapshot=true")
+    val response = httpPost(
+      s"/deployments/$id/_shutdown?hide=true&skip_snapshot=true"
+    )
     if (response.isEmpty) throw new RuntimeException(MSG_NO_RESPONSE)
     logger.info(
       s"deleteDeployment: Finished with status code ${response.get.statusCode}"
@@ -322,9 +327,30 @@ class CloudHttpClient {
   def resetPassword(id: String): Map[String, String] = {
     logger.info(s"Reset password: deployment $id")
     val response = httpPost(
-      s"/$id/elasticsearch/main-elasticsearch/_reset-password"
+      s"/deployments/$id/elasticsearch/main-elasticsearch/_reset-password"
     )
     if (response.isEmpty) throw new RuntimeException(MSG_NO_RESPONSE)
     response.get.jsonString.parseJson.convertTo[Map[String, String]]
+  }
+
+  def getDeployments: Map[String, String] = {
+    logger.info(s"Search for running deployments")
+    val response =
+      httpPost(
+        "/deployments/_search",
+        Helper.loadJsonString(searchDeploymentsTemplate)
+      )
+    val jsonString = response.get.jsonString
+    val names = jsonString
+      .extract[String](
+        Symbol("deployments") / elements / Symbol("name")
+      )
+      .toArray
+    val ids = jsonString
+      .extract[String](
+        Symbol("deployments") / elements / Symbol("id")
+      )
+      .toArray
+    Map() ++ (names zip ids)
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -44,4 +44,12 @@ class CloudAPITest {
 
     assertFalse(isReady)
   }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
+  def getDeploymentsTest(): Unit = {
+    val cloudClient = new CloudHttpClient
+    val items = cloudClient.getDeployments
+    assertTrue(!items.isEmpty)
+  }
 }


### PR DESCRIPTION
## Summary

PR is adding class to stop running deployments:
`export API_KEY=<your_cloud_key>`
`mvn exec:java -Dexec.mainClass=org.kibanaLoadTest.deploy.DeleteAll -Dexec.classpathScope=test -Dscope=all` will stop all running deployments:

```
21:48:44.724 [INFO ] httpClient - Search for running deployments
21:48:45.957 [INFO ] deploy:DeleteAll - Found 1 running deployments
21:48:45.957 [INFO ] deploy:DeleteAll - Deleting all deployments
21:48:45.958 [INFO ] deploy:DeleteAll - Got 1 deployments to delete
21:48:45.958 [INFO ] httpClient - deleteDeployment: Deployment bdcfa757001e41e883b60f373e43500c
21:48:47.308 [INFO ] httpClient - deleteDeployment: Finished with status code 200
21:49:09.311 [INFO ] httpClient - Search for running deployments
21:49:10.062 [INFO ] deploy:DeleteAll - Found 0 deployments after cleanup
```

Without `-Dscope=all` class will look only for `load-testing-<timestamp>` deployments and delete them (default use case)
With `-Denv=prod` class will run on production env, make sure to specify correct API_KEY

It will search for deployments, stop it 1 by 1 and later search for deployments again to confirm all were deleted
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added