### PR TITLE
[CI] fix kibana load-testing pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
         stage ('Running tests against locally build Kibana instance') {
             steps {
                 script {
+                    //restore default behaviour
+                    env.CI = ""
                     env.KIBANA_REPO_NAME = "${params.GITHUB_KIBANA_REPO_OWNER}/${params.GITHUB_KIBANA_REPO}"
                     env.KIBANA_BRANCH = "${params.GITHUB_KIBANA_BRANCH}"
                     echo "Using repo: git@github.com:${env.KIBANA_REPO_NAME}"


### PR DESCRIPTION
## Summary

Jobs are failing with `GCS_UPLOAD_PREFIX environment variable is not set and must always be set on CI`
This PR is about to fix it

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added