### PR TITLE
[ci] run the latest 7.x snapshot on Cloud

### DIFF
--- a/.ci/Jenkinsfile_cloud
+++ b/.ci/Jenkinsfile_cloud
@@ -28,7 +28,6 @@ pipeline {
                 script {
                     loadPipeline = load "${env.WORKSPACE}/kibana-load-testing/.ci/loadPipeline.groovy"
                     env.NUMBER_TEST_RUNS = Integer.valueOf(params.NUMBER_TEST_RUNS) > MAX_TEST_RUNS ?  MAX_TEST_RUNS.toString() : params.NUMBER_TEST_RUNS
-                    env.NUMBER_DEPLOYMENTS = Integer.valueOf(params.NUMBER_DEPLOYMENTS) > MAX_DEPLOYMENTS ? MAX_DEPLOYMENTS.toString() : params.NUMBER_DEPLOYMENTS
                 }
             }
         }
@@ -36,32 +35,26 @@ pipeline {
             steps {
                 echo "All scenarios will be executed ${env.NUMBER_TEST_RUNS} times on ${env.NUMBER_DEPLOYMENTS} deployments"
                 script {
-                    for (def i = 1; i <= Integer.valueOf(env.NUMBER_DEPLOYMENTS); i++) {
-                        threads[i] = {
-                            docker.image(MAVEN_IMAGE).inside('-u root') {
-                                withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY') {
-                                    sh """./kibana-load-testing/scripts/deploy_and_test.sh \
-                                        -v '${params.STACK_VERSION}' \
-                                        -c '${params.DEPLOY_CONFIG}' \
-                                        -s '${params.SIMULATION}' \
-                                        -n '${env.NUMBER_TEST_RUNS}'
-                                    """
-                                }
-                                loadPipeline.uploadGatlingReport()
-                                if (params.INGEST_RESULTS.toBoolean()) {
-                                    withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'host', variable_name: 'HOST_FROM_VAULT') {
-                                        withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'username', variable_name: 'USER_FROM_VAULT') {
-                                            withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'password', variable_name: 'PASS_FROM_VAULT') {
-                                                sh '''./kibana-load-testing/scripts/ingest_results.sh'''
-                                            }
-                                        }
+                    docker.image(MAVEN_IMAGE).inside('-u root') {
+                        withVaultSecret(secret: 'secret/kibana-issues/dev/cloud-staging-api-key', secret_field: 'value', variable_name: 'API_KEY') {
+                            sh """./kibana-load-testing/scripts/deploy_and_test.sh \
+                                -v '${params.STACK_VERSION}' \
+                                -c '${params.DEPLOY_CONFIG}' \
+                                -s '${params.SIMULATION}' \
+                                -n '${env.NUMBER_TEST_RUNS}'
+                               """
+                        }
+                        loadPipeline.uploadGatlingReport()
+                        if (params.INGEST_RESULTS.toBoolean()) {
+                            withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'host', variable_name: 'HOST_FROM_VAULT') {
+                                withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'username', variable_name: 'USER_FROM_VAULT') {
+                                    withVaultSecret(secret: 'secret/kibana-issues/prod/coverage/elasticsearch', secret_field: 'password', variable_name: 'PASS_FROM_VAULT') {
+                                        sh '''./kibana-load-testing/scripts/ingest_results.sh'''
                                     }
                                 }
                             }
                         }
                     }
-                    // Still within the 'Script' block, run the parallel array object
-                    parallel threads
                 }
             }
         }

--- a/scripts/deploy_and_test.sh
+++ b/scripts/deploy_and_test.sh
@@ -20,29 +20,37 @@ echo "##### Install dependencies #####"
 mvn --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -q install -DskipTests
 echo "##### Compile source code #####"
 mvn --no-transfer-progress scala:testCompile
-echo "##### Create a new Elastic Stack deployment #####"
-mvn --no-transfer-progress exec:java -Dexec.mainClass=org.kibanaLoadTest.deploy.Create \
-  -Dexec.classpathScope=test -Dexec.cleanupDaemonThreads=false \
-  -DcloudStackVersion="${stackVersion}" \
-  -DdeploymentConfig="${deployConfig}"
-source target/cloudDeployment.txt
 
-echo "##### Running tests against Kibana cloud instance ${deploymentId} #####"
+IFS=',' read -ra version_array <<< "${stackVersion}"
 IFS=',' read -ra sim_array <<< "${simulation}"
-for i in $(seq "$test_runs_number"); do
-  for j in "${sim_array[@]}"; do
-    echo "Running simulation $j $i-time..."
-    mvn gatling:test -q -DdeploymentId="${deploymentId}" -Dgatling.simulationClass=org.kibanaLoadTest.simulation.$j
-    # wait a minute between scenarios
-    sleep 1m
+
+for version in "${version_array[@]}"; do
+  echo "##### Create a new ${version} Elastic Stack deployment #####"
+  mvn --no-transfer-progress exec:java -Dexec.mainClass=org.kibanaLoadTest.deploy.Create \
+    -Dexec.classpathScope=test -Dexec.cleanupDaemonThreads=false \
+    -DcloudStackVersion="${version}" \
+    -DdeploymentConfig="${deployConfig}"
+  # check deployment file and apply env variables
+  if [ ! -f target/cloudDeployment.txt ]; then
+	  echo "!!!Deployment failed!!!"
+	  continue
+  fi
+  source target/cloudDeployment.txt
+  echo "##### Running tests against Kibana cloud instance ${deploymentId} #####"
+  for i in $(seq "$test_runs_number"); do
+    for j in "${sim_array[@]}"; do
+      echo "Running simulation $j $i-time..."
+      mvn gatling:test -q -DdeploymentId="${deploymentId}" -Dgatling.simulationClass=org.kibanaLoadTest.simulation.$j
+      # wait a minute between scenarios
+      sleep 1m
+    done
   done
+
+  echo "##### Delete deployment ${deploymentId} #####"
+  mvn --no-transfer-progress exec:java -Dexec.mainClass=org.kibanaLoadTest.deploy.Delete \
+    -Dexec.classpathScope=test -Dexec.cleanupDaemonThreads=false \
+    -DdeploymentId="${deploymentId}"
 done
 
-echo "##### Delete deployment ${deploymentId} #####"
-mvn --no-transfer-progress exec:java -Dexec.mainClass=org.kibanaLoadTest.deploy.Delete \
-  -Dexec.classpathScope=test -Dexec.cleanupDaemonThreads=false \
-  -DdeploymentId="${deploymentId}" || exit
-
 echo "##### Zip test report #####"
-cd ..
-tar -czf report.tar.gz kibana-load-testing/target/gatling/**/*
+cd .. && tar -czf report.tar.gz kibana-load-testing/target/gatling/**/*

--- a/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
+++ b/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
@@ -15,10 +15,12 @@ object Create {
     val deployConfig: String =
       System.getProperty("deploymentConfig", "config/deploy/default.conf")
     val versionString: String = System.getProperty("cloudStackVersion")
-    // validate version
-    val version = new Version(versionString)
 
     val cloudClient = new CloudHttpClient
+    val version = if (versionString == "7.x") {
+      cloudClient.getLatestAvailableVersion(versionString)
+    } else new Version(versionString)
+
     val payload = cloudClient.preparePayload(
       version.get,
       Helper.readResourceConfigFile(deployConfig)

--- a/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
+++ b/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
@@ -10,6 +10,7 @@ object Create {
     .toAbsolutePath
     .normalize
     .toString + File.separator + "cloudDeployment.txt"
+  private val LATEST_AVAILABLE = ".x"
 
   def main(args: Array[String]): Unit = {
     val deployConfig: String =
@@ -17,8 +18,10 @@ object Create {
     val versionString: String = System.getProperty("cloudStackVersion")
 
     val cloudClient = new CloudHttpClient
-    val version = if (versionString == "7.x") {
-      cloudClient.getLatestAvailableVersion(versionString)
+    val version = if (versionString.endsWith(LATEST_AVAILABLE)) {
+      cloudClient.getLatestAvailableVersion(
+        versionString.replace(LATEST_AVAILABLE, "")
+      )
     } else new Version(versionString)
 
     val payload = cloudClient.preparePayload(

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -372,4 +372,15 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
       )
     if (seq.isEmpty) null else seq.apply(0)
   }
+
+  def getLatestAvailableVersion(prefix: String): Version = {
+    // get the latest available version on Cloud
+    val versions = this
+      .getVersions()
+      .filter(s => s.startsWith(prefix))
+      .map(s => new Version(s))
+      .sorted
+    // get the last version in sorted array
+    versions(versions.length - 1)
+  }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -355,4 +355,21 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
       .toArray
     Map() ++ (names zip ids)
   }
+
+  def getVersions(): Array[String] = {
+    logger.info(s"Get available version")
+    val response = httpGet(
+      "/platform/configuration/templates/deployments/global"
+    )
+    val jsonString = response.get.jsonString
+    val seq = jsonString
+      .extract[Array[String]](
+        filter(
+          "template_category_id".is[String](_ == "compute-optimized")
+        ) / Symbol("regions") / filter(
+          "region_id".is[String](_ == "gcp-us-central1")
+        ) / Symbol("versions")
+      )
+    if (seq.isEmpty) null else seq.apply(0)
+  }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -370,7 +370,7 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
           "region_id".is[String](_ == "gcp-us-central1")
         ) / Symbol("versions")
       )
-    if (seq.isEmpty) null else seq.apply(0)
+    if (seq.isEmpty) null else seq.head
   }
 
   def getLatestAvailableVersion(prefix: String): Version = {
@@ -381,6 +381,6 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
       .map(s => new Version(s))
       .sorted
     // get the last version in sorted array
-    versions(versions.length - 1)
+    if (versions.isEmpty) null else versions.last
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
@@ -10,6 +10,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
 object SimulationHelper {
 
   val logger: Logger = LoggerFactory.getLogger("SimulationHelper")
+  val LATEST_AVAILABLE = ".x"
 
   private val lastRunFilePath: String = Paths
     .get("target")
@@ -24,8 +25,10 @@ object SimulationHelper {
     val config =
       Helper.readResourceConfigFile(deployFile)
     val cloudClient = new CloudHttpClient
-    val version = if (stackVersion == "7.x") {
-      cloudClient.getLatestAvailableVersion(stackVersion)
+    val version = if (stackVersion.endsWith(LATEST_AVAILABLE)) {
+      cloudClient.getLatestAvailableVersion(
+        stackVersion.replace(LATEST_AVAILABLE, "")
+      )
     } else new Version(stackVersion)
     val providerName = if (version.isAbove79x) "cloud-basic" else "basic-cloud"
     val payload = cloudClient.preparePayload(stackVersion, config)

--- a/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
@@ -25,14 +25,7 @@ object SimulationHelper {
       Helper.readResourceConfigFile(deployFile)
     val cloudClient = new CloudHttpClient
     val version = if (stackVersion == "7.x") {
-      // get the latest available version on Cloud
-      val versions = cloudClient
-        .getVersions()
-        .filter(s => s.startsWith("7.x"))
-        .map(s => new Version(s))
-        .sorted
-      // get the last version in sorted array
-      versions(versions.length - 1)
+      cloudClient.getLatestAvailableVersion(stackVersion)
     } else new Version(stackVersion)
     val providerName = if (version.isAbove79x) "cloud-basic" else "basic-cloud"
     val payload = cloudClient.preparePayload(stackVersion, config)

--- a/src/test/scala/org/kibanaLoadTest/helpers/Version.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Version.scala
@@ -3,13 +3,16 @@ package org.kibanaLoadTest.helpers
 class Version(var str: String) extends Comparable[Version] {
   if (str == null) throw new IllegalArgumentException("Version can not be null")
   var value: String = str.toUpperCase
-  if (!value.matches("[0-9]+(\\.[0-9]+)*(-SNAPSHOT)?"))
+  if (!value.matches("[0-9]+(\\.[0-9]+){1,}(-SNAPSHOT(?:.+)?)?"))
     throw new IllegalArgumentException(
-      s"Invalid version format '$value', supported formats: '7.11.0' or '7.11.0-SNAPSHOT'"
+      s"Invalid version format '$value', supported formats: '7.11.0' or '7.11.0-SNAPSHOT-*'"
     )
 
-  val postfix: String = if (value.indexOf("-SNAPSHOT") > 0) "SNAPSHOT" else ""
-  val version: String = value.replace("-SNAPSHOT", "")
+  val postfix: String =
+    if (value.indexOf("-SNAPSHOT") > 0)
+      value.slice(value.indexOf("-SNAPSHOT"), value.length)
+    else ""
+  val version: String = value.replaceAll("-SNAPSHOT(?:.+)?", "")
 
   def isAbove79x: Boolean = {
     this.compareTo(new Version("7.10")) != -1
@@ -32,6 +35,8 @@ class Version(var str: String) extends Comparable[Version] {
     }
     0
   }
+
+  override def toString: String = this.value
 
   final def get: String = this.value
 }

--- a/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/CloudAPITest.scala
@@ -52,4 +52,12 @@ class CloudAPITest {
     val items = cloudClient.getDeployments
     assertTrue(!items.isEmpty)
   }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
+  def getLatestAvailableVersionTest(): Unit = {
+    val cloudClient = new CloudHttpClient
+    val version = cloudClient.getLatestAvailableVersion("7.")
+    assertTrue(version.get.startsWith("7."))
+  }
 }


### PR DESCRIPTION
## Summary

Closes #92

With this PR you can pass multiple stack version in `STACK_VERSION` job parameter: for each version deployment is created, scenarios are run, deployment is deleted.

- you can provide sequence of existing versions, e.g. `7.11.1, 7.13.0-SNAPSHOT,8.0.0-SNAPSHOT`
- you can use `.x` to get the latest available version on Cloud, e.g `7.11.x,7.x`  

Deployments/scenarios are run in a sequence to avoid confusing with ingested test results. It means job time is going up by specifying multiple versions; it should be kept in mind.

Default value: `7.x,8.0.0-SNAPSHOT`, replace if you don't need to test 2 versions
Scheduled daily run uses the default value

![image](https://user-images.githubusercontent.com/10977896/116994413-f8157000-acd8-11eb-98bd-7b46c654e33a.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [x] Unit tests are added