### PR TITLE
Add configs for hardware profiles

### DIFF
--- a/src/test/resources/cloudPayload/createDeployment.json
+++ b/src/test/resources/cloudPayload/createDeployment.json
@@ -1,176 +1,212 @@
 {
-  "name":"_title",
+  "name":"title",
   "resources":{
-    "elasticsearch": [
+    "elasticsearch":[
       {
-        "region": "gcp-us-central1",
-        "settings": {
-          "dedicated_masters_threshold": 6
+        "region":"gcp-us-central1",
+        "settings":{
+          "dedicated_masters_threshold":6
         },
-        "plan": {
-          "cluster_topology": [
+        "plan":{
+          "autoscaling_enabled":false,
+          "cluster_topology":[
             {
-              "zone_count": 2,
-              "instance_configuration_id": "gcp.coordinating.1",
-              "node_roles": [
+              "zone_count":2,
+              "instance_configuration_id":"gcp.coordinating.1",
+              "node_roles":[
                 "ingest",
                 "remote_cluster_client"
               ],
-              "id": "coordinating",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"coordinating",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             },
             {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "hot"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"hot"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highio.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highmem.1",
+              "node_roles":[
                 "master",
                 "ingest",
-                "remote_cluster_client",
-                "data_hot",
                 "transform",
+                "data_hot",
+                "remote_cluster_client",
                 "data_content"
               ],
-              "id": "hot_content",
-              "size": {
-                "resource": "memory",
-                "value": 8192
+              "id":"hot_content",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "warm"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"warm"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highstorage.1",
+              "node_roles":[
                 "data_warm",
                 "remote_cluster_client"
               ],
-              "id": "warm",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"warm",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "cold"
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"cold"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highstorage.1",
+              "node_roles":[
                 "data_cold",
                 "remote_cluster_client"
               ],
-              "id": "cold",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"cold",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 3,
-              "instance_configuration_id": "gcp.master.1",
-              "node_roles": [
-                "master"
-              ],
-              "id": "master",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"frozen"
+                },
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "instance_configuration_id":"gcp.es.datafrozen.n2d.64x8x95",
+              "node_roles":[
+                "data_frozen"
+              ],
+              "id":"frozen",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "instance_configuration_id": "gcp.ml.1",
-              "node_roles": [
+              "zone_count":3,
+              "instance_configuration_id":"gcp.master.1",
+              "node_roles":[
+                "master",
+                "remote_cluster_client"
+              ],
+              "id":"master",
+              "size":{
+                "resource":"memory",
+                "value":0
+              },
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
+              }
+            },
+            {
+              "zone_count":1,
+              "instance_configuration_id":"gcp.ml.1",
+              "node_roles":[
                 "ml",
                 "remote_cluster_client"
               ],
-              "id": "ml",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"ml",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             }
           ],
-          "elasticsearch": {
-            "version": "X"
+          "elasticsearch":{
+            "version":"X"
           },
-          "deployment_template": {
-            "id": "gcp-io-optimized"
+          "deployment_template":{
+            "id":"gcp-memory-optimized"
           }
         },
-        "ref_id": "main-elasticsearch"
+        "ref_id":"main-elasticsearch"
       }
     ],
-    "enterprise_search": [],
-    "kibana": [
+    "enterprise_search":[
+
+    ],
+    "kibana":[
       {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
+        "elasticsearch_cluster_ref_id":"main-elasticsearch",
+        "region":"gcp-us-central1",
+        "plan":{
+          "cluster_topology":[
             {
-              "instance_configuration_id": "gcp.kibana.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "instance_configuration_id":"gcp.kibana.1",
+              "zone_count":1,
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             }
           ],
-          "kibana": {
-            "version": "X"
+          "kibana":{
+            "version":"X"
           }
         },
-        "ref_id": "main-kibana"
+        "ref_id":"main-kibana"
       }
     ],
-    "apm": [
+    "apm":[
       {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
+        "elasticsearch_cluster_ref_id":"main-elasticsearch",
+        "region":"gcp-us-central1",
+        "plan":{
+          "cluster_topology":[
             {
-              "instance_configuration_id": "gcp.apm.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 512
+              "instance_configuration_id":"gcp.apm.1",
+              "zone_count":1,
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             }
           ],
-          "apm": {
-            "version": "X"
+          "apm":{
+            "version":"X"
           }
         },
-        "ref_id": "main-apm"
+        "ref_id":"main-apm"
       }
     ]
   },

--- a/src/test/resources/cloudPayload/createDeployment.json
+++ b/src/test/resources/cloudPayload/createDeployment.json
@@ -1,5 +1,4 @@
 {
-  "name":"title",
   "resources":{
     "elasticsearch":[
       {
@@ -38,7 +37,7 @@
 
                 ]
               },
-              "instance_configuration_id":"gcp.data.highmem.1",
+              "instance_configuration_id":"gcp.data.highio.1",
               "node_roles":[
                 "master",
                 "ingest",
@@ -50,7 +49,7 @@
               "id":"hot_content",
               "size":{
                 "resource":"memory",
-                "value":0
+                "value":8192
               }
             },
             {
@@ -153,10 +152,10 @@
             }
           ],
           "elasticsearch":{
-            "version":"X"
+            "version":"7.13.0"
           },
           "deployment_template":{
-            "id":"gcp-memory-optimized"
+            "id":"gcp-io-optimized"
           }
         },
         "ref_id":"main-elasticsearch"
@@ -176,12 +175,12 @@
               "zone_count":1,
               "size":{
                 "resource":"memory",
-                "value":0
+                "value":1024
               }
             }
           ],
           "kibana":{
-            "version":"X"
+            "version":"7.13.0"
           }
         },
         "ref_id":"main-kibana"
@@ -198,18 +197,19 @@
               "zone_count":1,
               "size":{
                 "resource":"memory",
-                "value":0
+                "value":512
               }
             }
           ],
           "apm":{
-            "version":"X"
+            "version":"7.13.0"
           }
         },
         "ref_id":"main-apm"
       }
     ]
   },
+  "name":"i-o-optimized-deployment",
   "metadata":{
     "system_owned":false
   }

--- a/src/test/resources/cloudPayload/createDeployment.json
+++ b/src/test/resources/cloudPayload/createDeployment.json
@@ -1,44 +1,40 @@
 {
-  "resources":{
-    "elasticsearch":[
+  "resources": {
+    "elasticsearch": [
       {
-        "region":"gcp-us-central1",
-        "settings":{
-          "dedicated_masters_threshold":6
+        "region": "gcp-us-central1",
+        "settings": {
+          "dedicated_masters_threshold": 6
         },
-        "plan":{
-          "autoscaling_enabled":false,
-          "cluster_topology":[
+        "plan": {
+          "autoscaling_enabled": false,
+          "cluster_topology": [
             {
-              "zone_count":2,
-              "instance_configuration_id":"gcp.coordinating.1",
-              "node_roles":[
+              "zone_count": 2,
+              "instance_configuration_id": "gcp.coordinating.1",
+              "node_roles": [
                 "ingest",
                 "remote_cluster_client"
               ],
-              "id":"coordinating",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "coordinating",
+              "size": {
+                "resource": "memory",
+                "value": 0
               },
-              "elasticsearch":{
-                "enabled_built_in_plugins":[
-
-                ]
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
               }
             },
             {
-              "zone_count":2,
-              "elasticsearch":{
-                "node_attributes":{
-                  "data":"hot"
+              "zone_count": 2,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "hot"
                 },
-                "enabled_built_in_plugins":[
-
-                ]
+                "enabled_built_in_plugins": []
               },
-              "instance_configuration_id":"gcp.data.highio.1",
-              "node_roles":[
+              "instance_configuration_id": "gcp.data.highio.1",
+              "node_roles": [
                 "master",
                 "ingest",
                 "transform",
@@ -46,171 +42,159 @@
                 "remote_cluster_client",
                 "data_content"
               ],
-              "id":"hot_content",
-              "size":{
-                "resource":"memory",
-                "value":8192
+              "id": "hot_content",
+              "size": {
+                "resource": "memory",
+                "value": 8192
               }
             },
             {
-              "zone_count":2,
-              "elasticsearch":{
-                "node_attributes":{
-                  "data":"warm"
+              "zone_count": 2,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "warm"
                 },
-                "enabled_built_in_plugins":[
-
-                ]
+                "enabled_built_in_plugins": []
               },
-              "instance_configuration_id":"gcp.data.highstorage.1",
-              "node_roles":[
+              "instance_configuration_id": "gcp.data.highstorage.1",
+              "node_roles": [
                 "data_warm",
                 "remote_cluster_client"
               ],
-              "id":"warm",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "warm",
+              "size": {
+                "resource": "memory",
+                "value": 0
               }
             },
             {
-              "zone_count":1,
-              "elasticsearch":{
-                "node_attributes":{
-                  "data":"cold"
+              "zone_count": 1,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "cold"
                 },
-                "enabled_built_in_plugins":[
-
-                ]
+                "enabled_built_in_plugins": []
               },
-              "instance_configuration_id":"gcp.data.highstorage.1",
-              "node_roles":[
+              "instance_configuration_id": "gcp.data.highstorage.1",
+              "node_roles": [
                 "data_cold",
                 "remote_cluster_client"
               ],
-              "id":"cold",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "cold",
+              "size": {
+                "resource": "memory",
+                "value": 0
               }
             },
             {
-              "zone_count":1,
-              "elasticsearch":{
-                "node_attributes":{
-                  "data":"frozen"
+              "zone_count": 1,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "frozen"
                 },
-                "enabled_built_in_plugins":[
-
-                ]
+                "enabled_built_in_plugins": []
               },
-              "instance_configuration_id":"gcp.es.datafrozen.n2d.64x8x95",
-              "node_roles":[
+              "instance_configuration_id": "gcp.es.datafrozen.n2d.64x8x95",
+              "node_roles": [
                 "data_frozen"
               ],
-              "id":"frozen",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "frozen",
+              "size": {
+                "resource": "memory",
+                "value": 0
               }
             },
             {
-              "zone_count":3,
-              "instance_configuration_id":"gcp.master.1",
-              "node_roles":[
+              "zone_count": 3,
+              "instance_configuration_id": "gcp.master.1",
+              "node_roles": [
                 "master",
                 "remote_cluster_client"
               ],
-              "id":"master",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "master",
+              "size": {
+                "resource": "memory",
+                "value": 0
               },
-              "elasticsearch":{
-                "enabled_built_in_plugins":[
-
-                ]
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
               }
             },
             {
-              "zone_count":1,
-              "instance_configuration_id":"gcp.ml.1",
-              "node_roles":[
+              "zone_count": 1,
+              "instance_configuration_id": "gcp.ml.1",
+              "node_roles": [
                 "ml",
                 "remote_cluster_client"
               ],
-              "id":"ml",
-              "size":{
-                "resource":"memory",
-                "value":0
+              "id": "ml",
+              "size": {
+                "resource": "memory",
+                "value": 0
               },
-              "elasticsearch":{
-                "enabled_built_in_plugins":[
-
-                ]
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
               }
             }
           ],
-          "elasticsearch":{
-            "version":"7.13.0"
+          "elasticsearch": {
+            "version": "7.13.0"
           },
-          "deployment_template":{
-            "id":"gcp-io-optimized"
+          "deployment_template": {
+            "id": "gcp-io-optimized"
           }
         },
-        "ref_id":"main-elasticsearch"
+        "ref_id": "main-elasticsearch"
       }
     ],
-    "enterprise_search":[
-
-    ],
-    "kibana":[
+    "enterprise_search": [],
+    "kibana": [
       {
-        "elasticsearch_cluster_ref_id":"main-elasticsearch",
-        "region":"gcp-us-central1",
-        "plan":{
-          "cluster_topology":[
+        "elasticsearch_cluster_ref_id": "main-elasticsearch",
+        "region": "gcp-us-central1",
+        "plan": {
+          "cluster_topology": [
             {
-              "instance_configuration_id":"gcp.kibana.1",
-              "zone_count":1,
-              "size":{
-                "resource":"memory",
-                "value":1024
+              "instance_configuration_id": "gcp.kibana.1",
+              "zone_count": 1,
+              "size": {
+                "resource": "memory",
+                "value": 1024
               }
             }
           ],
-          "kibana":{
-            "version":"7.13.0"
+          "kibana": {
+            "version": "7.13.0"
           }
         },
-        "ref_id":"main-kibana"
+        "ref_id": "main-kibana"
       }
     ],
-    "apm":[
+    "apm": [
       {
-        "elasticsearch_cluster_ref_id":"main-elasticsearch",
-        "region":"gcp-us-central1",
-        "plan":{
-          "cluster_topology":[
+        "elasticsearch_cluster_ref_id": "main-elasticsearch",
+        "region": "gcp-us-central1",
+        "plan": {
+          "cluster_topology": [
             {
-              "instance_configuration_id":"gcp.apm.1",
-              "zone_count":1,
-              "size":{
-                "resource":"memory",
-                "value":512
+              "instance_configuration_id": "gcp.apm.1",
+              "zone_count": 1,
+              "size": {
+                "resource": "memory",
+                "value": 512
               }
             }
           ],
-          "apm":{
-            "version":"7.13.0"
+          "apm": {
+            "version": "7.13.0"
           }
         },
-        "ref_id":"main-apm"
+        "ref_id": "main-apm"
       }
     ]
   },
-  "name":"i-o-optimized-deployment",
-  "metadata":{
-    "system_owned":false
+  "name": "i-o-optimized-deployment",
+  "metadata": {
+    "system_owned": false
   }
 }

--- a/src/test/resources/config/deploy/apm-default.conf
+++ b/src/test/resources/config/deploy/apm-default.conf
@@ -1,6 +1,9 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {

--- a/src/test/resources/config/deploy/apm-disable-instrumentation.conf
+++ b/src/test/resources/config/deploy/apm-disable-instrumentation.conf
@@ -1,6 +1,9 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {

--- a/src/test/resources/config/deploy/apm-no-async.conf
+++ b/src/test/resources/config/deploy/apm-no-async.conf
@@ -1,6 +1,9 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {

--- a/src/test/resources/config/deploy/apm-no-metrics.conf
+++ b/src/test/resources/config/deploy/apm-no-metrics.conf
@@ -1,6 +1,9 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {

--- a/src/test/resources/config/deploy/apm-no-span-stacktrace.conf
+++ b/src/test/resources/config/deploy/apm-no-span-stacktrace.conf
@@ -1,6 +1,9 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {

--- a/src/test/resources/config/deploy/computeOptmized.conf
+++ b/src/test/resources/config/deploy/computeOptmized.conf
@@ -1,0 +1,15 @@
+elasticsearch {
+    deployment_template = "gcp-io-optimized"
+    hot_content {
+        instance_configuration_id = "gcp.data.highcpu.1"
+        memory = 8192
+    }
+}
+
+kibana {
+    memory = 1024
+}
+
+apm {
+    memory = 512
+}

--- a/src/test/resources/config/deploy/custom.conf
+++ b/src/test/resources/config/deploy/custom.conf
@@ -1,0 +1,18 @@
+elasticsearch {
+    deployment_template = "gcp-io-optimized"
+    autoscaling_enabled = true
+    hot_content {
+        zone_count = 3
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
+}
+
+kibana {
+    zone_count = 2
+    memory = 1024
+}
+
+apm {
+    memory = 512
+}

--- a/src/test/resources/config/deploy/default.conf
+++ b/src/test/resources/config/deploy/default.conf
@@ -1,8 +1,15 @@
 elasticsearch {
     deployment_template = "gcp-io-optimized"
-    memory = 8192
+    hot_content {
+        instance_configuration_id = "gcp.data.highio.1"
+        memory = 8192
+    }
 }
 
 kibana {
     memory = 1024
+}
+
+apm {
+    memory = 512
 }

--- a/src/test/resources/config/deploy/memoryOptimized.conf
+++ b/src/test/resources/config/deploy/memoryOptimized.conf
@@ -1,0 +1,15 @@
+elasticsearch {
+    deployment_template = "gcp-memory-optimized"
+    hot_content {
+        instance_configuration_id = "gcp.data.highmem.1"
+        memory = 8192
+    }
+}
+
+kibana {
+    memory = 1024
+}
+
+apm {
+    memory = 512
+}

--- a/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/CloudHttpClient.scala
@@ -128,9 +128,22 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
         .update(
           Symbol("resources") / Symbol("elasticsearch") / element(0) / Symbol(
             "plan"
-          ) / Symbol("cluster_topology") / element(0) / Symbol("size") / Symbol(
+          ) / Symbol("cluster_topology") / filter(
+            "id".is[String](_ == "hot_content")
+          ) / Symbol("instance_configuration_id") ! set[String](
+            config.getString(
+              "elasticsearch.hot_content.instance_configuration_id"
+            )
+          )
+        )
+        .update(
+          Symbol("resources") / Symbol("elasticsearch") / element(0) / Symbol(
+            "plan"
+          ) / Symbol("cluster_topology") / filter(
+            "id".is[String](_ == "hot_content")
+          ) / Symbol("size") / Symbol(
             "value"
-          ) ! set[Int](config.getInt("elasticsearch.memory"))
+          ) ! set[Int](config.getInt("elasticsearch.hot_content.memory"))
         )
         .update(
           Symbol("resources") / Symbol("kibana") / element(0) / Symbol(
@@ -148,6 +161,13 @@ class CloudHttpClient(var env: CloudEnv.Value = CloudEnv.STAGING) {
           Symbol("resources") / Symbol("apm") / element(0) / Symbol(
             "plan"
           ) / Symbol("apm") / Symbol("version") ! set[String](stackVersion)
+        )
+        .update(
+          Symbol("resources") / Symbol("apm") / element(0) / Symbol(
+            "plan"
+          ) / Symbol("cluster_topology") / element(0) / Symbol("size") / Symbol(
+            "value"
+          ) ! set[Int](config.getInt("apm.memory"))
         )
 
     def getNestedMap(basePath: String): Map[String, JsValue] = {


### PR DESCRIPTION
## Summary

Part of #98 

With this PR you can can create a more flexible cloud deployment, e.g.

```
elasticsearch {
    deployment_template = "gcp-io-optimized"
    autoscaling_enabled = true
    hot_content {
        zone_count = 3
        instance_configuration_id = "gcp.data.highio.1"
        memory = 8192
    }
}

kibana {
    zone_count = 2
    memory = 1024
}

apm {
    memory = 512
}
```
 
For a new deployment ES `hot_content` cluster will be in 3 zone instead of 2 and auto-scaling is on, Kibana will be in 2 zones instead of 1 by default.

![image](https://user-images.githubusercontent.com/10977896/117184780-67728900-add9-11eb-96de-83bbc219b098.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added