### PR TITLE
Branch testing: changing max users count

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Local  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 500
+  props.maxUsers = 600
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Local  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 600
+  props.maxUsers = 500
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Local  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 400
+  props.maxUsers = 500
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 500
+  props.maxUsers = 600
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 600
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 400
+  props.maxUsers = 500
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 700
+  props.maxUsers = 800
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Local discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 500
+  props.maxUsers = 600
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Local discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 600
+  props.maxUsers = 500
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Local discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 400
+  props.maxUsers = 500
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))


### PR DESCRIPTION
## Summary

With this PR the following changes are made:

- AtOnceJourney 500 users
- DiscoverAtOnce 500 users
- DemoJourney ramping up to 800 (~954 totally)
### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added