### PR TITLE
[ci] increase timeout to 2h for branch testing

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         string(name: 'SIMULATION', defaultValue: 'branch.DemoJourney,branch.AtOnceJourney,branch.DiscoverAtOnce,branch.TagCloudJourney,branch.TSVBGaugeJourney,branch.TSVBTimeSeriesJourney', description: 'Comma-separated simulation list')
     }
     options {
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
     }
     stages {
         stage ('Initialize') {


### PR DESCRIPTION
## Summary

This PR increases job timeout 90 -> 120 min. After adding 3 more simulations job time is around 80-95 min 
### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added