### PR TITLE
[dashboard] filter response by specific dashboard

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/scenario/Dashboard.scala
+++ b/src/test/scala/org/kibanaLoadTest/scenario/Dashboard.scala
@@ -31,18 +31,18 @@ object Dashboard {
         .header("Referer", baseUrl + "/app/dashboards")
         .check(status.is(200))
         .check(
-          jsonPath("$.saved_objects[0].id").find.saveAs("dashboardId")
+          jsonPath("$.saved_objects[?(@.attributes.title=='[eCommerce] Revenue Dashboard')].id").find.saveAs("dashboardId")
         )
         .check(
           jsonPath(
-            "$.saved_objects[0].references[?(@.type=='visualization')]"
+            "$.saved_objects[?(@.attributes.title=='[eCommerce] Revenue Dashboard')].references[?(@.type=='visualization')]"
           ).findAll
             .transform(_.map(_.replaceAll("\"name(.+?),", "")))
             .saveAs("vizVector")
         )
         .check(
           jsonPath(
-            "$.saved_objects[0].references[?(@.type=='map' || @.type=='search')]"
+            "$.saved_objects[?(@.attributes.title=='[eCommerce] Revenue Dashboard')].references[?(@.type=='map' || @.type=='search')]"
           ).findAll
             .transform(
               _.map(_.replaceAll("\"name(.+?),", ""))
@@ -59,7 +59,7 @@ object Dashboard {
           .header("Referer", baseUrl + "/app/dashboards")
           .check(status.is(200))
           .check(
-            jsonPath("$.saved_objects[?(@.type=='index-pattern')].id")
+            jsonPath("$.saved_objects[?(@.attributes.title=='kibana_sample_data_ecommerce')].id")
               .saveAs("indexPatternId")
           )
       )
@@ -96,7 +96,7 @@ object Dashboard {
         ).exec(
           http("query search & map")
             .post("/api/saved_objects/_bulk_get")
-            .body(StringBody("""[ ${searchAndMapString} ]""".stripMargin))
+            .body(StringBody("[${searchAndMapString}, {\"id\":\"${indexPatternId}\", \"type\":\"index-pattern\"}]"))
             .asJson
             .headers(headers)
             .header("Referer", baseUrl + "/app/dashboards")


### PR DESCRIPTION
## Summary

PR fixes parsing of 

`/api/saved_objects/_find?default_search_operator=AND&has_reference=%5B%5D&page=1&per_page=1000&search_fields=title%5E3&search_fields=description&type=dashboard` by filtering response by dashboard name


### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added