### PR TITLE
Branch/increase users for viz simulations

### DIFF
--- a/puppeteer/src/helpers/compare.ts
+++ b/puppeteer/src/helpers/compare.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 
 export function compareWithBaseline(scenario: string, actualSequence: Map<string, string[]>) {
     console.log(`${scenario} scenario: comparing recorded requestes with baseline:`);
-    const repeatableCalls = ['/internal/bsearch', '/api/saved_objects/_bulk_get'];
+    const repeatableCalls = ['/internal/bsearch', '/api/saved_objects/_bulk_get', '/api/canvas/fns'];
     let isUpdateRequired = false;
     let baselinePath = resolve(__dirname, '..', '..', 'baseline', scenario, 'requests.json');
     const expectedSequence = new Map(Object.entries(JSON.parse(fs.readFileSync(baselinePath, 'utf8')) as JSON)) as Map<string, string[]>;

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class TSVBGaugeJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 800
+  props.maxUsers = 1200
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class TSVBTimeSeriesJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 800
+  props.maxUsers = 1200
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TagCloudJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TagCloudJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class TagCloudJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 800
+  props.maxUsers = 1200
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(


### PR DESCRIPTION
## Summary

Increasing number of users 800->1200 for tag cloud/gauge/time series simulations

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added