### PR TITLE
[ci] exclude *.log files from artifacts

### DIFF
--- a/scripts/archive_results.sh
+++ b/scripts/archive_results.sh
@@ -9,5 +9,5 @@ fi
 GATLING_OUTPUT_DIR="kibana-load-testing/target/gatling/"
 if [ -d "$GATLING_OUTPUT_DIR" ]; then
   echo "archive gatling test results"
-  tar -czf report.tar.gz kibana-load-testing/target/gatling/**/*
+  tar --exclude='*.log' -czf report.tar.gz kibana-load-testing/target/gatling/**/*
 fi


### PR DESCRIPTION
## Summary

With response.log being part of report, artifacts archive for a single CI run is ~1GB. Since we ingest data from the log file, there is no need to keep it in report.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added