### PR TITLE
[ingest] use BulkRequest with 200 docs per chunk to ingest results faster

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
@@ -20,7 +20,8 @@ import java.io.IOException
 
 class ESClient(config: ESConfiguration) {
   val logger: Logger = LoggerFactory.getLogger("ES_Client")
-  val BULK_SIZE = 200
+  val BULK_SIZE =
+    Option(System.getenv("INGEST_BULK_SIZE")).map(_.toInt).getOrElse(200)
 
   def ingest(indexName: String, jsonList: List[Json]): Unit = {
     val credentialsProvider = new BasicCredentialsProvider

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
@@ -50,7 +50,7 @@ class ESClient(config: ESConfiguration) {
     try {
       logger.info(s"Ingesting to stats cluster: ${jsonList.size} docs")
 
-      val it = jsonList.sliding(BULK_SIZE, BULK_SIZE)
+      val it = jsonList.grouped(BULK_SIZE)
       val bulkBuffer = scala.collection.mutable.ListBuffer.empty[BulkRequest]
       while (it.hasNext) {
         val chunk = it.next()

--- a/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
@@ -77,12 +77,12 @@ class IngestionTest {
   }
 
   @Test
-  @EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
+  //@EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
   def ingestReportTest(): Unit = {
     val DATA_INDEX = "gatling-data"
-    val host = System.getenv("HOST_FROM_VAULT")
-    val username = System.getenv("USER_FROM_VAULT")
-    val password = System.getenv("PASS_FROM_VAULT")
+    val host = "http://localhost:9220" //System.getenv("HOST_FROM_VAULT")
+    val username = "elastic" //System.getenv("USER_FROM_VAULT")
+    val password = "changeme" //System.getenv("PASS_FROM_VAULT")
     val esConfig = new ESConfiguration(
       ConfigFactory.load
         .withValue("host", ConfigValueFactory.fromAnyRef(host))
@@ -91,9 +91,17 @@ class IngestionTest {
     )
 
     val esClient = new ESClient(esConfig)
-    val simLogFilePath = getClass.getResource("/test/simulation.log").getPath
-    val lastRunFilePath = getClass.getResource("/test/lastRun.txt").getPath
-    val responseFilePath = getClass.getResource("/test/response.log").getPath
+    val testPath =
+      Helper.getTargetPath + File.separator + "test-classes" + File.separator + "test" + File.separator
+    val simLogFilePath: String = new File(
+      testPath + "simulation.log"
+    ).getAbsolutePath
+    val lastRunFilePath: String = new File(
+      testPath + "lastRun.txt"
+    ).getAbsolutePath
+    val responseFilePath: String = new File(
+      testPath + "response.log"
+    ).getAbsolutePath
     val metaJson = Helper.getMetaJson(lastRunFilePath, simLogFilePath)
     val (requestsTimeline, concurrentUsers) =
       LogParser.parseSimulationLog(simLogFilePath)

--- a/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
@@ -77,12 +77,12 @@ class IngestionTest {
   }
 
   @Test
-  //@EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
+  @EnabledIfEnvironmentVariable(named = "ENV", matches = "local")
   def ingestReportTest(): Unit = {
     val DATA_INDEX = "gatling-data"
-    val host = "http://localhost:9220" //System.getenv("HOST_FROM_VAULT")
-    val username = "elastic" //System.getenv("USER_FROM_VAULT")
-    val password = "changeme" //System.getenv("PASS_FROM_VAULT")
+    val host = System.getenv("HOST_FROM_VAULT")
+    val username = System.getenv("USER_FROM_VAULT")
+    val password = System.getenv("PASS_FROM_VAULT")
     val esConfig = new ESConfiguration(
       ConfigFactory.load
         .withValue("host", ConfigValueFactory.fromAnyRef(host))


### PR DESCRIPTION
## Summary

Improve ingestion speed with `BulkRequest`

Before:
```
15:24:47.672 [INFO ] ES_Client - Ingesting to stats cluster: 6136 docs
15:26:06.109 [INFO ] ES_Client - Ingestion is completed
// 1 min 19 sec
...
15:26:11.165 [INFO ] ES_Client - Ingesting to stats cluster: 2662 docs
15:26:46.768 [INFO ] ES_Client - Ingestion is completed
// 35 sec
```

After
```
15:35:21.947 [INFO ] ES_Client - Ingesting to stats cluster: 6136 docs
15:35:37.739 [INFO ] ES_Client - Ingestion is completed
// 16 sec
...
15:35:37.765 [INFO ] ES_Client - Ingesting to stats cluster: 281 docs
15:35:37.913 [INFO ] ES_Client - Ingestion is completed
// 0.15 sec
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added