### PR TITLE
[cloud] don't deploy APM by default

### DIFF
--- a/src/test/resources/cloudPayload/createDeployment.json
+++ b/src/test/resources/cloudPayload/createDeployment.json
@@ -1,40 +1,26 @@
 {
-  "resources": {
-    "elasticsearch": [
+  "resources":{
+    "elasticsearch":[
       {
-        "region": "gcp-us-central1",
-        "settings": {
-          "dedicated_masters_threshold": 6
+        "region":"gcp-us-central1",
+        "settings":{
+          "dedicated_masters_threshold":6
         },
-        "plan": {
-          "autoscaling_enabled": false,
-          "cluster_topology": [
+        "plan":{
+          "autoscaling_enabled":false,
+          "cluster_topology":[
             {
-              "zone_count": 2,
-              "instance_configuration_id": "gcp.coordinating.1",
-              "node_roles": [
-                "ingest",
-                "remote_cluster_client"
-              ],
-              "id": "coordinating",
-              "size": {
-                "resource": "memory",
-                "value": 0
-              },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
-              }
-            },
-            {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "hot"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"hot"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highio.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.es.datahot.n2.68x10x45",
+              "node_roles":[
                 "master",
                 "ingest",
                 "transform",
@@ -42,159 +28,170 @@
                 "remote_cluster_client",
                 "data_content"
               ],
-              "id": "hot_content",
-              "size": {
-                "resource": "memory",
-                "value": 8192
+              "id":"hot_content",
+              "size":{
+                "resource":"memory",
+                "value":8192
               }
             },
             {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "warm"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"warm"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.es.datawarm.n2.68x10x190",
+              "node_roles":[
                 "data_warm",
                 "remote_cluster_client"
               ],
-              "id": "warm",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"warm",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "cold"
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"cold"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.es.datacold.n2.68x10x190",
+              "node_roles":[
                 "data_cold",
                 "remote_cluster_client"
               ],
-              "id": "cold",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"cold",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "frozen"
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"frozen"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.es.datafrozen.n2d.64x8x95",
-              "node_roles": [
+              "instance_configuration_id":"gcp.es.datafrozen.n2.68x10x95",
+              "node_roles":[
                 "data_frozen"
               ],
-              "id": "frozen",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"frozen",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 3,
-              "instance_configuration_id": "gcp.master.1",
-              "node_roles": [
+              "zone_count":3,
+              "instance_configuration_id":"gcp.es.master.n2.68x32x45",
+              "node_roles":[
                 "master",
                 "remote_cluster_client"
               ],
-              "id": "master",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"master",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             },
             {
-              "zone_count": 1,
-              "instance_configuration_id": "gcp.ml.1",
-              "node_roles": [
+              "zone_count":2,
+              "instance_configuration_id":"gcp.es.coordinating.n2.68x16x45",
+              "node_roles":[
+                "ingest",
+                "remote_cluster_client"
+              ],
+              "id":"coordinating",
+              "size":{
+                "resource":"memory",
+                "value":0
+              },
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
+              }
+            },
+            {
+              "zone_count":1,
+              "instance_configuration_id":"gcp.es.ml.n2.68x16x45",
+              "node_roles":[
                 "ml",
                 "remote_cluster_client"
               ],
-              "id": "ml",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"ml",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             }
           ],
-          "elasticsearch": {
-            "version": "7.13.0"
+          "elasticsearch":{
+            "version":"7.14.0"
           },
-          "deployment_template": {
-            "id": "gcp-io-optimized"
+          "deployment_template":{
+            "id":"gcp-storage-optimized"
           }
         },
-        "ref_id": "main-elasticsearch"
+        "ref_id":"main-elasticsearch"
       }
     ],
-    "enterprise_search": [],
-    "kibana": [
+    "enterprise_search":[
+
+    ],
+    "kibana":[
       {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
+        "elasticsearch_cluster_ref_id":"main-elasticsearch",
+        "region":"gcp-us-central1",
+        "plan":{
+          "cluster_topology":[
             {
-              "instance_configuration_id": "gcp.kibana.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 1024
+              "instance_configuration_id":"gcp.kibana.n2.68x32x45",
+              "zone_count":1,
+              "size":{
+                "resource":"memory",
+                "value":1024
               }
             }
           ],
-          "kibana": {
-            "version": "7.13.0"
+          "kibana":{
+            "version":"7.14.0"
           }
         },
-        "ref_id": "main-kibana"
+        "ref_id":"main-kibana"
       }
     ],
-    "apm": [
-      {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
-            {
-              "instance_configuration_id": "gcp.apm.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 512
-              }
-            }
-          ],
-          "apm": {
-            "version": "7.13.0"
-          }
-        },
-        "ref_id": "main-apm"
-      }
+    "apm":[
+
     ]
   },
-  "name": "i-o-optimized-deployment",
-  "metadata": {
-    "system_owned": false
+  "name":"My deployment",
+  "metadata":{
+    "system_owned":false
   }
 }

--- a/src/test/resources/cloudPayload/createExtendedDeployment.json
+++ b/src/test/resources/cloudPayload/createExtendedDeployment.json
@@ -1,0 +1,200 @@
+{
+  "resources": {
+    "elasticsearch": [
+      {
+        "region": "gcp-us-central1",
+        "settings": {
+          "dedicated_masters_threshold": 6
+        },
+        "plan": {
+          "autoscaling_enabled": false,
+          "cluster_topology": [
+            {
+              "zone_count": 2,
+              "instance_configuration_id": "gcp.coordinating.1",
+              "node_roles": [
+                "ingest",
+                "remote_cluster_client"
+              ],
+              "id": "coordinating",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
+              }
+            },
+            {
+              "zone_count": 2,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "hot"
+                },
+                "enabled_built_in_plugins": []
+              },
+              "instance_configuration_id": "gcp.data.highio.1",
+              "node_roles": [
+                "master",
+                "ingest",
+                "transform",
+                "data_hot",
+                "remote_cluster_client",
+                "data_content"
+              ],
+              "id": "hot_content",
+              "size": {
+                "resource": "memory",
+                "value": 8192
+              }
+            },
+            {
+              "zone_count": 2,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "warm"
+                },
+                "enabled_built_in_plugins": []
+              },
+              "instance_configuration_id": "gcp.data.highstorage.1",
+              "node_roles": [
+                "data_warm",
+                "remote_cluster_client"
+              ],
+              "id": "warm",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              }
+            },
+            {
+              "zone_count": 1,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "cold"
+                },
+                "enabled_built_in_plugins": []
+              },
+              "instance_configuration_id": "gcp.data.highstorage.1",
+              "node_roles": [
+                "data_cold",
+                "remote_cluster_client"
+              ],
+              "id": "cold",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              }
+            },
+            {
+              "zone_count": 1,
+              "elasticsearch": {
+                "node_attributes": {
+                  "data": "frozen"
+                },
+                "enabled_built_in_plugins": []
+              },
+              "instance_configuration_id": "gcp.es.datafrozen.n2d.64x8x95",
+              "node_roles": [
+                "data_frozen"
+              ],
+              "id": "frozen",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              }
+            },
+            {
+              "zone_count": 3,
+              "instance_configuration_id": "gcp.master.1",
+              "node_roles": [
+                "master",
+                "remote_cluster_client"
+              ],
+              "id": "master",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
+              }
+            },
+            {
+              "zone_count": 1,
+              "instance_configuration_id": "gcp.ml.1",
+              "node_roles": [
+                "ml",
+                "remote_cluster_client"
+              ],
+              "id": "ml",
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "elasticsearch": {
+                "enabled_built_in_plugins": []
+              }
+            }
+          ],
+          "elasticsearch": {
+            "version": "7.13.0"
+          },
+          "deployment_template": {
+            "id": "gcp-io-optimized"
+          }
+        },
+        "ref_id": "main-elasticsearch"
+      }
+    ],
+    "enterprise_search": [],
+    "kibana": [
+      {
+        "elasticsearch_cluster_ref_id": "main-elasticsearch",
+        "region": "gcp-us-central1",
+        "plan": {
+          "cluster_topology": [
+            {
+              "instance_configuration_id": "gcp.kibana.1",
+              "zone_count": 1,
+              "size": {
+                "resource": "memory",
+                "value": 1024
+              }
+            }
+          ],
+          "kibana": {
+            "version": "7.13.0"
+          }
+        },
+        "ref_id": "main-kibana"
+      }
+    ],
+    "apm": [
+      {
+        "elasticsearch_cluster_ref_id": "main-elasticsearch",
+        "region": "gcp-us-central1",
+        "plan": {
+          "cluster_topology": [
+            {
+              "instance_configuration_id": "gcp.apm.1",
+              "zone_count": 1,
+              "size": {
+                "resource": "memory",
+                "value": 512
+              }
+            }
+          ],
+          "apm": {
+            "version": "7.13.0"
+          }
+        },
+        "ref_id": "main-apm"
+      }
+    ]
+  },
+  "name": "i-o-optimized-deployment",
+  "metadata": {
+    "system_owned": false
+  }
+}

--- a/src/test/resources/cloudPayload/createExtendedDeployment.json
+++ b/src/test/resources/cloudPayload/createExtendedDeployment.json
@@ -1,40 +1,44 @@
 {
-  "resources": {
-    "elasticsearch": [
+  "resources":{
+    "elasticsearch":[
       {
-        "region": "gcp-us-central1",
-        "settings": {
-          "dedicated_masters_threshold": 6
+        "region":"gcp-us-central1",
+        "settings":{
+          "dedicated_masters_threshold":6
         },
-        "plan": {
-          "autoscaling_enabled": false,
-          "cluster_topology": [
+        "plan":{
+          "autoscaling_enabled":false,
+          "cluster_topology":[
             {
-              "zone_count": 2,
-              "instance_configuration_id": "gcp.coordinating.1",
-              "node_roles": [
+              "zone_count":2,
+              "instance_configuration_id":"gcp.coordinating.1",
+              "node_roles":[
                 "ingest",
                 "remote_cluster_client"
               ],
-              "id": "coordinating",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"coordinating",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             },
             {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "hot"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"hot"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highio.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highio.1",
+              "node_roles":[
                 "master",
                 "ingest",
                 "transform",
@@ -42,159 +46,171 @@
                 "remote_cluster_client",
                 "data_content"
               ],
-              "id": "hot_content",
-              "size": {
-                "resource": "memory",
-                "value": 8192
+              "id":"hot_content",
+              "size":{
+                "resource":"memory",
+                "value":8192
               }
             },
             {
-              "zone_count": 2,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "warm"
+              "zone_count":2,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"warm"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highstorage.1",
+              "node_roles":[
                 "data_warm",
                 "remote_cluster_client"
               ],
-              "id": "warm",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"warm",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "cold"
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"cold"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.data.highstorage.1",
-              "node_roles": [
+              "instance_configuration_id":"gcp.data.highstorage.1",
+              "node_roles":[
                 "data_cold",
                 "remote_cluster_client"
               ],
-              "id": "cold",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"cold",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 1,
-              "elasticsearch": {
-                "node_attributes": {
-                  "data": "frozen"
+              "zone_count":1,
+              "elasticsearch":{
+                "node_attributes":{
+                  "data":"frozen"
                 },
-                "enabled_built_in_plugins": []
+                "enabled_built_in_plugins":[
+
+                ]
               },
-              "instance_configuration_id": "gcp.es.datafrozen.n2d.64x8x95",
-              "node_roles": [
+              "instance_configuration_id":"gcp.es.datafrozen.n2d.64x8x95",
+              "node_roles":[
                 "data_frozen"
               ],
-              "id": "frozen",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"frozen",
+              "size":{
+                "resource":"memory",
+                "value":0
               }
             },
             {
-              "zone_count": 3,
-              "instance_configuration_id": "gcp.master.1",
-              "node_roles": [
+              "zone_count":3,
+              "instance_configuration_id":"gcp.master.1",
+              "node_roles":[
                 "master",
                 "remote_cluster_client"
               ],
-              "id": "master",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"master",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             },
             {
-              "zone_count": 1,
-              "instance_configuration_id": "gcp.ml.1",
-              "node_roles": [
+              "zone_count":1,
+              "instance_configuration_id":"gcp.ml.1",
+              "node_roles":[
                 "ml",
                 "remote_cluster_client"
               ],
-              "id": "ml",
-              "size": {
-                "resource": "memory",
-                "value": 0
+              "id":"ml",
+              "size":{
+                "resource":"memory",
+                "value":0
               },
-              "elasticsearch": {
-                "enabled_built_in_plugins": []
+              "elasticsearch":{
+                "enabled_built_in_plugins":[
+
+                ]
               }
             }
           ],
-          "elasticsearch": {
-            "version": "7.13.0"
+          "elasticsearch":{
+            "version":"7.13.0"
           },
-          "deployment_template": {
-            "id": "gcp-io-optimized"
+          "deployment_template":{
+            "id":"gcp-io-optimized"
           }
         },
-        "ref_id": "main-elasticsearch"
+        "ref_id":"main-elasticsearch"
       }
     ],
-    "enterprise_search": [],
-    "kibana": [
+    "enterprise_search":[
+
+    ],
+    "kibana":[
       {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
+        "elasticsearch_cluster_ref_id":"main-elasticsearch",
+        "region":"gcp-us-central1",
+        "plan":{
+          "cluster_topology":[
             {
-              "instance_configuration_id": "gcp.kibana.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 1024
+              "instance_configuration_id":"gcp.kibana.1",
+              "zone_count":1,
+              "size":{
+                "resource":"memory",
+                "value":1024
               }
             }
           ],
-          "kibana": {
-            "version": "7.13.0"
+          "kibana":{
+            "version":"7.13.0"
           }
         },
-        "ref_id": "main-kibana"
+        "ref_id":"main-kibana"
       }
     ],
-    "apm": [
+    "apm":[
       {
-        "elasticsearch_cluster_ref_id": "main-elasticsearch",
-        "region": "gcp-us-central1",
-        "plan": {
-          "cluster_topology": [
+        "elasticsearch_cluster_ref_id":"main-elasticsearch",
+        "region":"gcp-us-central1",
+        "plan":{
+          "cluster_topology":[
             {
-              "instance_configuration_id": "gcp.apm.1",
-              "zone_count": 1,
-              "size": {
-                "resource": "memory",
-                "value": 512
+              "instance_configuration_id":"gcp.apm.1",
+              "zone_count":1,
+              "size":{
+                "resource":"memory",
+                "value":512
               }
             }
           ],
-          "apm": {
-            "version": "7.13.0"
+          "apm":{
+            "version":"7.13.0"
           }
         },
-        "ref_id": "main-apm"
+        "ref_id":"main-apm"
       }
     ]
   },
-  "name": "i-o-optimized-deployment",
-  "metadata": {
-    "system_owned": false
+  "name":"i-o-optimized-deployment",
+  "metadata":{
+    "system_owned":false
   }
 }

--- a/src/test/resources/config/deploy/computeOptmized.conf
+++ b/src/test/resources/config/deploy/computeOptmized.conf
@@ -10,8 +10,4 @@ kibana {
     memory = 1024
 }
 
-apm {
-    memory = 512
-}
-
 category = "cpu-optimized"

--- a/src/test/resources/config/deploy/default.conf
+++ b/src/test/resources/config/deploy/default.conf
@@ -10,8 +10,4 @@ kibana {
     memory = 1024
 }
 
-apm {
-    memory = 512
-}
-
 category = "general-purpose"

--- a/src/test/resources/config/deploy/memoryOptimized.conf
+++ b/src/test/resources/config/deploy/memoryOptimized.conf
@@ -10,8 +10,4 @@ kibana {
     memory = 1024
 }
 
-apm {
-    memory = 512
-}
-
 category = "general-purpose"

--- a/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
+++ b/src/test/scala/org/kibanaLoadTest/deploy/Create.scala
@@ -30,19 +30,25 @@ object Create {
       version.get,
       deployConfig
     )
-    var metadata = cloudClient.createDeployment(payload)
-    val isReady = cloudClient.waitForClusterToStart(metadata("deploymentId"))
+    var deployment = cloudClient.createDeployment(payload)
+    val isReady = cloudClient.waitForClusterToStart(deployment)
     // delete deployment if it was not finished successfully
     if (!isReady) {
-      cloudClient.deleteDeployment(metadata("deploymentId"))
+      cloudClient.deleteDeployment(deployment.id)
       throw new RuntimeException("Stop due to failed deployment...")
     }
 
-    val host = cloudClient.getKibanaUrl(metadata("deploymentId"))
-    metadata += "version" -> version.get
-    metadata += "host" -> host
-    // do not delete deployment after simulation run
-    metadata += "deleteDeploymentOnFinish" -> "false"
+    val host = cloudClient.getKibanaUrl(deployment.id)
+
+    val metadata = Map(
+      "deploymentId" -> deployment.id,
+      "username" -> deployment.username,
+      "password" -> deployment.password,
+      "version" -> version.get,
+      "host" -> host,
+      // do not delete deployment after simulation run
+      "deleteDeploymentOnFinish" -> "false"
+    )
 
     Helper.writeMapToFile(metadata, cloudDeploymentFilePath)
   }

--- a/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/SimulationHelper.scala
@@ -33,19 +33,19 @@ object SimulationHelper {
     } else new Version(stackVersion)
     val providerName = if (version.isAbove79x) "cloud-basic" else "basic-cloud"
     val payload = cloudClient.preparePayload(stackVersion, config)
-    val metadata = cloudClient.createDeployment(payload)
-    val isReady = cloudClient.waitForClusterToStart(metadata("deploymentId"))
+    val deployment = cloudClient.createDeployment(payload)
+    val isReady = cloudClient.waitForClusterToStart(deployment)
     // delete deployment if it was not finished successfully
     if (!isReady) {
-      cloudClient.deleteDeployment(metadata("deploymentId"))
+      cloudClient.deleteDeployment(deployment.id)
       throw new RuntimeException("Stop due to failed deployment...")
     }
-    val host = cloudClient.getKibanaUrl(metadata("deploymentId"))
+    val host = cloudClient.getKibanaUrl(deployment.id)
     val cloudConfig = ConfigFactory
       .load()
       .withValue(
         "deploymentId",
-        ConfigValueFactory.fromAnyRef(metadata("deploymentId"))
+        ConfigValueFactory.fromAnyRef(deployment.id)
       )
       .withValue("app.host", ConfigValueFactory.fromAnyRef(host))
       .withValue(
@@ -60,11 +60,11 @@ object SimulationHelper {
       )
       .withValue(
         "auth.username",
-        ConfigValueFactory.fromAnyRef(metadata("username"))
+        ConfigValueFactory.fromAnyRef(deployment.username)
       )
       .withValue(
         "auth.password",
-        ConfigValueFactory.fromAnyRef(metadata("password"))
+        ConfigValueFactory.fromAnyRef(deployment.password)
       )
 
     new KibanaConfiguration(cloudConfig)


### PR DESCRIPTION
## Summary

To speed up process and depend less on APM stability, default cluster will include only ES and Kibana.
To create deployment with APM it now requires to have it explicitly specified in `.conf` file:

```
apm {
    memory = 1024
}
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/view/Kibana/job/elastic+kibana+load-testing-cloud/528/) 
- [ ] Unit tests are added