### PR TITLE
[chore] remove deprecated until json method

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -1,5 +1,7 @@
 package org.kibanaLoadTest.helpers
 
+import com.google.gson.Gson
+
 import java.io.{File, PrintWriter}
 import java.net.{MalformedURLException, URL}
 import java.nio.file.{Files, Paths, StandardCopyOption}
@@ -15,7 +17,6 @@ import spray.json.JsonParser
 import spray.json.JsonParser.ParsingException
 
 import scala.io.Source
-import scala.util.parsing.json.JSONObject
 
 object Helper {
   val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
@@ -179,7 +180,7 @@ object Helper {
         .getSimulationClass(simLogFilePath),
       "timestamp" -> convertDateToUTC(Instant.now.toEpochMilli)
     )
-    parse(JSONObject(meta).toString()).getOrElse(Json.Null)
+    parse((new Gson).toJson(meta)).getOrElse(Json.Null)
   }
 
   def updateValues(str: String, kv: Map[String, String]): String = {
@@ -214,7 +215,7 @@ object Helper {
     UUID.randomUUID.toString
   }
 
-  def moveResponseLogToResultsDir: Unit = {
+  def moveResponseLogToResultsDir(): Unit = {
     val lastReportPath = getLastReportPath
     val regexp = "[\\w|\\/\\-\\+]+response-\\d{14}.log"
     val targetFiles = getTargetFiles
@@ -229,7 +230,7 @@ object Helper {
       throw new RuntimeException("response.log file is not found in /target")
     }
     Files.move(
-      Paths.get(responseLogsPaths(0)),
+      Paths.get(responseLogsPaths.head),
       Paths.get(lastReportPath + File.separator + "response.log"),
       StandardCopyOption.REPLACE_EXISTING
     )

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -106,7 +106,7 @@ class BaseSimulation extends Simulation {
   after {
     SimulationHelper.copyRunConfigurationToReportPath()
     // move response log from /target to gatling report folder
-    moveResponseLogToResultsDir
+    moveResponseLogToResultsDir()
     if (
       appConfig.deploymentId.isDefined && appConfig.deleteDeploymentOnFinish
     ) {


### PR DESCRIPTION
## Summary

This PR fixes

```
08:28:17.539 [main][WARN ][ZincCompiler.scala:183] i.g.c.ZincCompiler$ - /Users/dzmitrylemechko/elastic/github/kibana-load-testing/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala:182:11: class JSONObject in package json is deprecated (since 1.0.6): Use The Scala Library Index to find alternatives: https://index.scala-lang.org/
    parse(JSONObject(meta).toString()).getOrElse(Json.Null)
          ^
08:28:19.367 [main][WARN ][ZincCompiler.scala:144] i.g.c.ZincCompiler$ - one warning found
```

by switching to `Gson` library
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added