### PR TITLE
[ingestion] convert map to java collection for GSON

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -15,6 +15,7 @@ import io.circe.parser.parse
 import org.slf4j.{Logger, LoggerFactory}
 import spray.json.JsonParser
 import spray.json.JsonParser.ParsingException
+import scala.jdk.CollectionConverters._
 
 import scala.io.Source
 
@@ -180,7 +181,7 @@ object Helper {
         .getSimulationClass(simLogFilePath),
       "timestamp" -> convertDateToUTC(Instant.now.toEpochMilli)
     )
-    parse((new Gson).toJson(meta)).getOrElse(Json.Null)
+    parse(new Gson().toJson(meta.asJava)).getOrElse(Json.Null)
   }
 
   def updateValues(str: String, kv: Map[String, String]): String = {


### PR DESCRIPTION
## Summary

Fixing ingestion failure:
```
08:38:13  org.elasticsearch.ElasticsearchStatusException: Elasticsearch exception [type=illegal_argument_exception, reason=mapper [rootNode.content] cannot be changed from type [date] to [text]]
08:38:13      at org.elasticsearch.rest.BytesRestResponse.errorFromXContent (BytesRestResponse.java:176)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.parseEntity (RestHighLevelClient.java:2011)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.parseResponseException (RestHighLevelClient.java:1988)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest (RestHighLevelClient.java:1745)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.performRequest (RestHighLevelClient.java:1702)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity (RestHighLevelClient.java:1672)
08:38:13      at org.elasticsearch.client.RestHighLevelClient.index (RestHighLevelClient.java:1029)
08:38:13      at org.kibanaLoadTest.helpers.ESClient.$anonfun$ingest$3 (ESClient.scala:55)
08:38:13      at scala.collection.IterableOnceOps.foreach (IterableOnce.scala:563)
08:38:13      at scala.collection.IterableOnceOps.foreach$ (IterableOnce.scala:561)
08:38:13      at scala.collection.AbstractIterator.foreach (Iterator.scala:1288)
08:38:13      at scala.collection.parallel.ParIterableLike$Foreach.leaf (ParIterableLike.scala:938)
08:38:13      at scala.collection.parallel.Task.$anonfun$tryLeaf$1 (Tasks.scala:52)
08:38:13      at scala.runtime.java8.JFunction0$mcV$sp.apply (JFunction0$mcV$sp.scala:18)
08:38:13      at scala.util.control.Breaks$$anon$1.catchBreak (Breaks.scala:97)
08:38:13      at scala.collection.parallel.Task.tryLeaf (Tasks.scala:55)
08:38:13      at scala.collection.parallel.Task.tryLeaf$ (Tasks.scala:49)
08:38:13      at scala.collection.parallel.ParIterableLike$Foreach.tryLeaf (ParIterableLike.scala:935)
08:38:13      at scala.collection.parallel.AdaptiveWorkStealingTasks$AWSTWrappedTask.compute (Tasks.scala:152)
08:38:13      at scala.collection.parallel.AdaptiveWorkStealingTasks$AWSTWrappedTask.compute$ (Tasks.scala:148)
08:38:13      at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$AWSFJTWrappedTask.compute (Tasks.scala:304)
08:38:13      at java.util.concurrent.RecursiveAction.exec (RecursiveAction.java:189)
08:38:13      at java.util.concurrent.ForkJoinTask.doExec (ForkJoinTask.java:289)
08:38:13      at java.util.concurrent.ForkJoinPool$WorkQueue.runTask (ForkJoinPool.java:1056)
08:38:13      at java.util.concurrent.ForkJoinPool.runWorker (ForkJoinPool.java:1692)
08:38:13      at java.util.concurrent.ForkJoinWorkerThread.run (ForkJoinWorkerThread.java:175)
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added