### PR TITLE
[ingest] set default size to 100 for bulk request

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
@@ -20,8 +20,9 @@ import java.io.IOException
 
 class ESClient(config: ESConfiguration) {
   val logger: Logger = LoggerFactory.getLogger("ES_Client")
+  val BULK_SIZE_DEFAULT = 100
   val BULK_SIZE =
-    Option(System.getenv("INGEST_BULK_SIZE")).map(_.toInt).getOrElse(200)
+    Option(System.getenv("INGEST_BULK_SIZE")).map(_.toInt).getOrElse(300)
 
   def ingest(indexName: String, jsonList: List[Json]): Unit = {
     val credentialsProvider = new BasicCredentialsProvider
@@ -51,7 +52,9 @@ class ESClient(config: ESConfiguration) {
     try {
       logger.info(s"Ingesting to stats cluster: ${jsonList.size} docs")
 
-      val it = jsonList.grouped(BULK_SIZE)
+      val bulkSize =
+        if (indexName == "gatling-data") BULK_SIZE_DEFAULT else BULK_SIZE
+      val it = jsonList.grouped(bulkSize)
       val bulkBuffer = scala.collection.mutable.ListBuffer.empty[BulkRequest]
       while (it.hasNext) {
         val chunk = it.next()


### PR DESCRIPTION
## Summary

Fixes Jenkins error in run [670](https://kibana-ci.elastic.co/view/Kibana/job/elastic+kibana+load-testing/670)
```
11:21:31  ElasticsearchStatusException[Unable to parse response body]; nested: ResponseException[method [POST], host [https://********], URI [/_bulk?timeout=1m], status line [HTTP/1.1 413 Request Entity Too Large]
11:21:31  ];
11:21:31  	at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1991)
11:21:31  	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1745)
11:21:31  	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1702)
11:21:31  	at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1672)
```
### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added