### PR TITLE
[cloud] bump concurrent users up to 100/250

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Cloud  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 200
+  props.maxUsers = 400
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Cloud  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 400
+  props.maxUsers = 100
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Cloud  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 100
+  props.maxUsers = 120
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Cloud  atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 80
+  props.maxUsers = 200
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 250
+  props.maxUsers = 220
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 400
+  props.maxUsers = 250
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 200
+  props.maxUsers = 400
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DemoJourney.scala
@@ -8,6 +8,8 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Demo journey ${appConfig.buildVersion}"
 
+  props.maxUsers = 200
+
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(
       Login

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Cloud discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 200
+  props.maxUsers = 400
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Cloud discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 80
+  props.maxUsers = 200
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/cloud/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Cloud discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 400
+  props.maxUsers = 250
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))


### PR DESCRIPTION
## Summary

Gatling stats shows significant improvement so it makes sense to increase the load

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added