### PR TITLE
[helper] fix moveResponseLogToResultsDir to support 7.x

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -218,7 +218,7 @@ object Helper {
 
   def moveResponseLogToResultsDir(): Unit = {
     val lastReportPath = getLastReportPath
-    val regexp = "[\\w|\\/\\-\\+]+response-\\d{14}.log"
+    val regexp = "[\\w|\\/\\-\\+\\.\\_\\@\\{\\}\\[\\]]+response-\\d{14}.log"
     val targetFiles = getTargetFiles
     targetFiles.foreach(p => println(p))
     val responseLogsPaths =


### PR DESCRIPTION
## Summary

Fixes pipeline failure for 7.x branch

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added