### PR TITLE
[ingest] do not ingest response headers and body

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ResponseParser.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ResponseParser.scala
@@ -97,6 +97,11 @@ object ResponseParser {
             .getOrElse("")
         }
 
+        if (status == "OK") {
+          responseHeaders = ""
+          responseBody = ""
+        }
+
         responseList += Response(
           userId,
           name,


### PR DESCRIPTION
## Summary

With this PR we will ingest actual response headers and body only when request status is `KO`, meaning Gatling identified it as failure. By default both fields will have empty string.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added