### PR TITLE
ingest total user count and avg user session time

### DIFF
--- a/src/test/resources/test/global_stats.json
+++ b/src/test/resources/test/global_stats.json
@@ -1,0 +1,73 @@
+{
+    "name": "Global Information",
+    "numberOfRequests": {
+        "total": 17537,
+        "ok": 17033,
+        "ko": 504
+    },
+    "minResponseTime": {
+        "total": 19,
+        "ok": 19,
+        "ko": 60000
+    },
+    "maxResponseTime": {
+        "total": 60007,
+        "ok": 59252,
+        "ko": 60007
+    },
+    "meanResponseTime": {
+        "total": 9030,
+        "ok": 7521,
+        "ko": 60000
+    },
+    "standardDeviation": {
+        "total": 11327,
+        "ok": 7277,
+        "ko": 1
+    },
+    "percentiles1": {
+        "total": 4988,
+        "ok": 4874,
+        "ko": 60000
+    },
+    "percentiles2": {
+        "total": 8401,
+        "ok": 6989,
+        "ko": 60000
+    },
+    "percentiles3": {
+        "total": 25102,
+        "ok": 22160,
+        "ko": 60001
+    },
+    "percentiles4": {
+        "total": 60000,
+        "ok": 32119,
+        "ko": 60001
+    },
+    "group1": {
+    "name": "t < 800 ms",
+    "count": 352,
+    "percentage": 2
+},
+    "group2": {
+    "name": "800 ms < t < 1200 ms",
+    "count": 151,
+    "percentage": 1
+},
+    "group3": {
+    "name": "t > 1200 ms",
+    "count": 16530,
+    "percentage": 94
+},
+    "group4": {
+    "name": "failed",
+    "count": 504,
+    "percentage": 3
+},
+    "meanNumberOfRequestsPerSecond": {
+        "total": 49.12324929971989,
+        "ok": 47.71148459383753,
+        "ko": 1.411764705882353
+    }
+}

--- a/src/test/resources/test/testRun.txt
+++ b/src/test/resources/test/testRun.txt
@@ -1,0 +1,17 @@
+CI_BUILD_URL=https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/842/
+branch=main
+maxUsers=500
+isCloudDeployment=false
+version=8.1.0
+baseUrl=http://localhost:5620
+CI_BUILD_ID=842
+isSnapshotBuild=true
+esBuildHash=ab4581b805ae15d9e3cf3f41dcc7e0498d4b722b
+esVersion=8.1.0-SNAPSHOT
+buildHash=82979a345f93d7f59662b32dd0db6f696f2f245e
+kibanaBranch=main
+deploymentId=
+esBuildDate=2021-12-06T15:05:33.690016977Z
+esLuceneVersion=9.0.0
+esUrl=http://localhost:9220
+buildNumber=48913

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -275,7 +275,7 @@ object Helper {
     val metaJson = Helper.getMetaJson(testRunFilePath, simLogFilePath)
     val usersStatsJsonString: String = s"""
       {
-      "usersCountTotal": ${usersStats.count},
+      "totalUsersCount": ${usersStats.count},
       "avgUserSessionTime": ${usersStats.avgSessionTime}
       }
     """

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -251,7 +251,7 @@ object Helper {
         Source.fromFile(statsFilePath).getLines().mkString
       )
     val statsJson = parse(statsJsonString).getOrElse(Json.Null)
-    val (requestsTimeline, concurrentUsers) =
+    val (requestsTimeline, concurrentUsers, usersStats) =
       LogParser.parseSimulationLog(simLogFilePath)
     val responses = ResponseParser.getRequests(responseFilePath)
 
@@ -273,8 +273,16 @@ object Helper {
     }
 
     val metaJson = Helper.getMetaJson(testRunFilePath, simLogFilePath)
+    val usersStatsJsonString: String = s"""
+      {
+      "usersCountTotal": ${usersStats.count},
+      "avgUserSessionTime": ${usersStats.avgSessionTime}
+      }
+    """
     // final Json objects to ingest
-    val combinedStatsJson = statsJson.deepMerge(metaJson)
+    val combinedStatsJson = statsJson
+      .deepMerge(metaJson)
+      .deepMerge(parse(usersStatsJsonString).getOrElse(Json.Null))
     val requestJsonArray = responses.par
       .map(response => {
         val gson = new Gson

--- a/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
@@ -41,7 +41,7 @@ class IngestionTest {
         + File.separator + "test" + File.separator
         + "simulation.log"
     ).getAbsolutePath
-    val (requestsTimeline, concurrentUsers) =
+    val (requestsTimeline, concurrentUsers, usersStats) =
       LogParser.parseSimulationLog(logFilePath)
     assertEquals(
       expRequestRecordCount,


### PR DESCRIPTION
## Summary

This PR adds 2 fields to gatling-stats index and for each simulation we gonna have few more metrics:

- `totalUsersCount` showing how many virtual users totally went through journey  
- `avgUserSessionTIme` showing avg time of user journey, basically how much time its takes to run all the requests on average

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added