### PR TITLE
[branch] decrease max users for all simulations

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/AtOnceJourney.scala
@@ -10,7 +10,7 @@ class AtOnceJourney extends BaseSimulation {
     s"Branch atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 400
+  props.maxUsers = 200
 
   val scnDiscover: ScenarioBuilder = scenario(scenarioName("discover"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
@@ -13,7 +13,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class CanvasJourney extends BaseSimulation {
   val scenarioName = s"Branch canvas journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 200
+  props.maxUsers = 100
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DashboardJourney extends BaseSimulation {
   val scenarioName = s"Branch dashboard journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 1000
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DemoJourney extends BaseSimulation {
   val scenarioName = s"Branch demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 400
+  props.maxUsers = 200
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverAtOnce.scala
@@ -18,7 +18,7 @@ class DiscoverAtOnce extends BaseSimulation {
     s"Branch discover atOnce $module ${appConfig.buildVersion}"
   }
 
-  props.maxUsers = 500
+  props.maxUsers = 300
 
   val scnDiscover1: ScenarioBuilder = scenario(scenarioName("discover query 1"))
     .exec(loginStep.pause(props.loginPause))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class DiscoverJourney extends BaseSimulation {
   val scenarioName = s"Branch demo journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 1200
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class LensJourney extends BaseSimulation {
   val scenarioName = s"Branch lens journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 1000
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class TSVBGaugeJourney extends BaseSimulation {
   val scenarioName = s"Branch gauge journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 1200
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
@@ -8,7 +8,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 class TSVBTimeSeriesJourney extends BaseSimulation {
   val scenarioName = s"Branch timeSeries journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 1200
+  props.maxUsers = 700
 
   val scn: ScenarioBuilder = scenario(scenarioName)
     .exec(


### PR DESCRIPTION
## Summary

This PR put the max numbers of users down as experiment to track trend stability

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added