### PR TITLE
Add override to cluster uuid

### DIFF
--- a/cfg/metricbeat/metricbeat.yml
+++ b/cfg/metricbeat/metricbeat.yml
@@ -184,3 +184,4 @@ processors:
 # This allows to enable 6.7 migration aliases
 #migration.6_to_7.enabled: truefields.build: :
 logging.to_stderr: True
+monitoring.override_cluster_uuid: Dima-s-awesome-cluster


### PR DESCRIPTION
This should fix the long list of clusters in the monitoring window.
New  has the same length as the ones already set so it should work just fine. I guess we have to run the test a few time after merging to confirm that this is right.