### PR TITLE
Adding a pipeline to set the cluster UUID

### DIFF
--- a/cfg/metricbeat/metricbeat.yml
+++ b/cfg/metricbeat/metricbeat.yml
@@ -76,7 +76,7 @@ setup.kibana:
 # `setup.kibana.host` options.
 # You can find the `cloud.id` in the Elastic Cloud web UI.
 cloud.id: kibana-code-coverage:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxNDJmZWEyZDMwNDc0ODZlOTI1ZWI4YjIyMzU1OWNhZSRhNmIxMTgzZmQwZmI0ODZkYmRlMGU0YjYyODA0M2NmNA==
-
+output.elasticsearch.pipeline: cluster_uuid_pipeline
 # The cloud.auth setting overwrites the `output.elasticsearch.username` and
 # `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
 #cloud.auth: beats_ingester:changeme   - replaced with Vault


### PR DESCRIPTION
Found a pipeline setting for metricbeat output, hopefully it also works for cloud.id and for monitoring data. 
https://www.elastic.co/guide/en/beats/metricbeat/7.16/configuring-ingest-node.html

I've already created the pipeline in Kibana Stats that sets the cluster uuid to : "dima-s-awesome-cluster" 