### PR TITLE
checkout faster

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,11 +39,15 @@ pipeline {
                     $class: 'GitSCM',
                     branches: [[name: "${env.KIBANA_BRANCH}"]],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kibana']],
+                    extensions: [
+                        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'kibana'],
+                        [$class: 'CloneOption', depth: 20, noTags: true, shallow: true]
+                    ],
                     submoduleCfg: [],
                     userRemoteConfigs: [[
                         credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                         url: "git@github.com:${env.KIBANA_REPO_NAME}",
+                        refspec: '+refs/heads/main:refs/remotes/origin/main'
                     ]],
                 ])
                 script {


### PR DESCRIPTION
## Summary

Speeds up kibana repo clone process by lmiting number of commits to 20, no tags, etc.
### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added