### PR TITLE
Add warmup stage for simulations

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.scala
@@ -90,7 +90,7 @@ class ESClient(config: ESConfiguration) {
           val bulkResponse =
             client.bulk(bulkBuffer(j).request, RequestOptions.DEFAULT)
           bulkResponse.getTook.toString
-          logger.debug(
+          logger.info(
             s"Bulk size=${bulkBuffer(j).size} ingested within: ${bulkResponse.getTook.toString}"
           )
           if (bulkResponse.hasFailures) {

--- a/src/test/scala/org/kibanaLoadTest/helpers/Response.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Response.scala
@@ -3,6 +3,7 @@ package org.kibanaLoadTest.helpers
 case class Response(
     userId: String,
     name: String,
+    simulation: String,
     status: String,
     method: String,
     url: String,
@@ -28,6 +29,7 @@ object Response {
   def apply(
       userId: String,
       name: String,
+      simulation: String,
       status: String,
       method: String,
       url: String,
@@ -43,6 +45,7 @@ object Response {
     Response(
       userId,
       name,
+      simulation,
       status,
       method,
       url,

--- a/src/test/scala/org/kibanaLoadTest/helpers/ResponseParser.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ResponseParser.scala
@@ -13,6 +13,7 @@ object ResponseParser {
   private val REQUEST_BODY_REGEXP = "(?<=content=).*(?=\\})".r
   private val RESPONSE_BODY_REGEXP = "(?<=body:).*".r
   private val RESPONSE_STATUS_CODE_REGEXP = "\\d{3}".r
+  private val SESSION_REGEXP = "(?<=Session\\().*(?=\\))".r
   private val STATUS_REGEXP = "OK|KO".r
   private val STATUS_MESSAGE_REGEXP = "(?:OK|KO).*$"
   private val ERROR_MESSAGE_REGEXP = "(?<=KO).*".r
@@ -51,7 +52,9 @@ object ResponseParser {
           sessionValue = sessionValue + strLine.trim
           strLine = br.readLine
         }
-        val userId = sessionValue.split(",")(1)
+        val session = SESSION_REGEXP.findFirstIn(sessionValue).getOrElse("")
+        val simulation = session.split(",")(0)
+        val userId = session.split(",")(1)
         strLine = br.readLine
         // HTTP request:
         val requestStr = br.readLine()
@@ -105,6 +108,7 @@ object ResponseParser {
         responseList += Response(
           userId,
           name,
+          simulation,
           status,
           method,
           url,

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
@@ -12,7 +12,7 @@ import org.kibanaLoadTest.simulation.BaseSimulation
 
 class CanvasJourney extends BaseSimulation {
   val scenarioName = "CanvasJourney"
-  props.maxUsers = 100
+  props.maxUsers = 200
 
   val steps = exec(
     Login
@@ -37,7 +37,7 @@ class CanvasJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
@@ -11,28 +11,35 @@ import org.kibanaLoadTest.scenario.{Canvas, Login}
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class CanvasJourney extends BaseSimulation {
-  val scenarioName = s"Branch canvas journey ${appConfig.buildVersion}"
-
+  val scenarioName = "CanvasJourney"
   props.maxUsers = 100
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(Canvas.loadWorkpad(appConfig.baseUrl, defaultHeaders))
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(Canvas.loadWorkpad(appConfig.baseUrl, defaultHeaders))
+
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
 
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (1 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
@@ -32,7 +32,7 @@ class DashboardJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
@@ -6,28 +6,35 @@ import org.kibanaLoadTest.scenario.{Dashboard, Login}
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class DashboardJourney extends BaseSimulation {
-  val scenarioName = s"Branch dashboard journey ${appConfig.buildVersion}"
+  val scenarioName = s"DashboardJourney"
+  props.maxUsers = 500
 
-  props.maxUsers = 700
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
 
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (1 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -6,37 +6,39 @@ import org.kibanaLoadTest.scenario.{Canvas, Dashboard, Discover, Login, Home}
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class DemoJourney extends BaseSimulation {
-  val scenarioName = s"Branch demo journey ${appConfig.buildVersion}"
-
+  val scenarioName = "DemoJourney"
   props.maxUsers = 200
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(Home.load(appConfig.baseUrl, defaultHeaders).pause(10))
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(Home.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Discover.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Discover.do2ExtraQueries(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Canvas.loadWorkpad(appConfig.baseUrl, defaultHeaders))
 
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
+
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (3 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
-
-  // generate a closed workload injection profile
-  // with levels of 10, 15, 20, 25 and 30 concurrent users
-  // each level lasting 10 seconds
-  // separated by linear ramps lasting 10 seconds
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -36,7 +36,7 @@ class DemoJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
@@ -33,7 +33,7 @@ class DiscoverJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -2,40 +2,50 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.http.Predef.{http, status}
 import org.kibanaLoadTest.scenario.{Lens, Login}
 import org.kibanaLoadTest.simulation.BaseSimulation
+import io.gatling.http.Predef._
 
 class LensJourney extends BaseSimulation {
   val scenarioName = s"Branch lens journey ${appConfig.buildVersion}"
 
-  props.maxUsers = 700
+  props.maxUsers = 200
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(
-      Lens
-        .load(
-          "c762b7a0-f5ea-11eb-a78e-83aac3c38a60",
-          appConfig.baseUrl,
-          defaultHeaders
-        )
-        .pause(5)
-    )
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(
+    Lens
+      .load(
+        "c762b7a0-f5ea-11eb-a78e-83aac3c38a60",
+        appConfig.baseUrl,
+        defaultHeaders
+      )
+      .pause(5)
+  )
+
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
 
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (1 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -2,15 +2,12 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import io.gatling.http.Predef.{http, status}
 import org.kibanaLoadTest.scenario.{Lens, Login}
 import org.kibanaLoadTest.simulation.BaseSimulation
-import io.gatling.http.Predef._
 
 class LensJourney extends BaseSimulation {
-  val scenarioName = s"Branch lens journey ${appConfig.buildVersion}"
-
-  props.maxUsers = 200
+  val scenarioName = "LensJourney"
+  props.maxUsers = 500
 
   val steps = exec(
     Login

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -40,7 +40,7 @@ class LensJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
@@ -6,38 +6,45 @@ import org.kibanaLoadTest.scenario.{Login, Visualize}
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class TSVBGaugeJourney extends BaseSimulation {
-  val scenarioName = s"Branch gauge journey ${appConfig.buildVersion}"
+  val scenarioName = "GaugeJourney"
+  props.maxUsers = 500
 
-  props.maxUsers = 700
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(
+    Visualize
+      .load(
+        "tsvb",
+        "b80e6540-b891-11e8-a6d9-e546fe2bba5f",
+        "data/visualize/gauge_sold_per_day.json",
+        appConfig.baseUrl,
+        defaultHeaders
+      )
+      .pause(5)
+  )
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(
-      Visualize
-        .load(
-          "tsvb",
-          "b80e6540-b891-11e8-a6d9-e546fe2bba5f",
-          "data/visualize/gauge_sold_per_day.json",
-          appConfig.baseUrl,
-          defaultHeaders
-        )
-        .pause(5)
-    )
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
 
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (1 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
@@ -42,7 +42,7 @@ class TSVBGaugeJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
@@ -6,38 +6,45 @@ import org.kibanaLoadTest.scenario.{Visualize, Login}
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class TSVBTimeSeriesJourney extends BaseSimulation {
-  val scenarioName = s"Branch timeSeries journey ${appConfig.buildVersion}"
+  val scenarioName = s"TimeSeriesJourney"
+  props.maxUsers = 500
 
-  props.maxUsers = 700
+  val steps = exec(
+    Login
+      .doLogin(
+        appConfig.isSecurityEnabled,
+        appConfig.loginPayload,
+        appConfig.loginStatusCode
+      )
+      .pause(5)
+  ).exec(
+    Visualize
+      .load(
+        "tsvb",
+        "45e07720-b890-11e8-a6d9-e546fe2bba5f",
+        "data/visualize/time_series_promotion_tracking.json",
+        appConfig.baseUrl,
+        defaultHeaders
+      )
+      .pause(5)
+  )
 
-  val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(
-      Visualize
-        .load(
-          "tsvb",
-          "45e07720-b890-11e8-a6d9-e546fe2bba5f",
-          "data/visualize/time_series_promotion_tracking.json",
-          appConfig.baseUrl,
-          defaultHeaders
-        )
-        .pause(5)
-    )
+  val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
+  val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)
 
   setUp(
-    scn
+    warmupScn
       .inject(
-        constantConcurrentUsers(20) during (1 * 60), // 1
-        rampConcurrentUsers(20) to props.maxUsers during (3 * 60) // 2
+        constantConcurrentUsers(20) during (1 * 30),
+        rampConcurrentUsers(20) to props.maxUsers during (2 * 60)
       )
       .protocols(httpProtocol)
+      .andThen(
+        scn
+          .inject(
+            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+          )
+          .protocols(httpProtocol)
+      )
   ).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
@@ -42,7 +42,7 @@ class TSVBTimeSeriesJourney extends BaseSimulation {
       .andThen(
         scn
           .inject(
-            constantConcurrentUsers(props.maxUsers) during (3 * 60)
+            constantConcurrentUsers(props.maxUsers) during (4 * 60)
           )
           .protocols(httpProtocol)
       )


### PR DESCRIPTION
## Summary

PR splits each simulation into 2 scenarios: warmup and main one

- warmup includes
  - 1st stage of 20 concurrent users during 30 sec
  - 2nd stage of ramping concurrent users from 20 to <max> during 2 minutes
- main includes
  - <max> concurrent users during 4 minutes
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added