### PR TITLE
[ci] Run FTR from kibana rootDir

### DIFF
--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -86,6 +86,8 @@ cp -pR install/kibana/. $WORKSPACE/kibana-build/
 
 echo " -> Setup env for tests"
 source test/scripts/jenkins_test_setup_xpack.sh
+# back to $KIBANA_DIR
+cd $KIBANA_DIR
 
 ## Start Metricbeat
 #echo " -> Starting metricbeat"
@@ -104,7 +106,7 @@ for i in "${sim_array[@]}"; do
   export GATLING_SIMULATIONS="$i"
   node scripts/functional_tests \
     --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/load/config.ts;
+    --config x-pack/test/load/config.ts;
 done
 
 echo " -> Simulations run is finished"


### PR DESCRIPTION
## Summary

Fix load testing execution on Jenkins by running FTR from root.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/view/Kibana/job/elastic+kibana+load-testing/1531)
- [ ] Unit tests are added