### PR TITLE
[Ingestion/Results reporting] Disable response logging

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -20,18 +20,18 @@
         </encoder>
     </appender>
 
-    <appender name="FILE_RESP" class="ch.qos.logback.core.FileAppender">
-        <file>target/response-${date}.log</file>
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
-        </encoder>
-    </appender>
+<!--    <appender name="FILE_RESP" class="ch.qos.logback.core.FileAppender">-->
+<!--        <file>target/response-${date}.log</file>-->
+<!--        <encoder>-->
+<!--            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>-->
+<!--        </encoder>-->
+<!--    </appender>-->
 
     <!-- uncomment and set to DEBUG to log all failing HTTP requests -->
     <!-- uncomment and set to TRACE to log all HTTP requests -->
-    <logger name="io.gatling.http.engine.response" level="TRACE" additivity="false">
-        <appender-ref ref="FILE_RESP"/>
-    </logger>
+<!--    <logger name="io.gatling.http.engine.response" level="TRACE" additivity="false">-->
+<!--        <appender-ref ref="FILE_RESP"/>-->
+<!--    </logger>-->
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/Helper.scala
@@ -225,29 +225,6 @@ object Helper {
     UUID.randomUUID.toString
   }
 
-  def moveResponseLogToResultsDir(): Unit = {
-    val lastReportPath = getLastReportPath
-    val regexp = "[\\w|\\/\\-\\+\\.\\_\\@\\{\\}\\[\\]]+response-\\d{14}.log"
-    val targetFiles = getTargetFiles
-    targetFiles.foreach(p => println(p))
-    val responseLogsPaths =
-      targetFiles
-        .filter(p => p matches regexp)
-        .filter(p =>
-          new File(p).length() > 1000
-        ) // sometimes Gatling leaves extra empty log file
-    if (responseLogsPaths.isEmpty) {
-      throw new RuntimeException("response.log file is not found in /target")
-    }
-    Files.move(
-      Paths.get(responseLogsPaths.head),
-      Paths.get(lastReportPath + File.separator + "response.log"),
-      StandardCopyOption.REPLACE_EXISTING
-    )
-    // delete all listed response-*.log files
-    responseLogsPaths.foreach(p => Files.deleteIfExists(Paths.get(p)))
-  }
-
   def prepareDocsForIngestion(
       statsFilePath: String,
       simLogFilePath: String,

--- a/src/test/scala/org/kibanaLoadTest/ingest/Main.scala
+++ b/src/test/scala/org/kibanaLoadTest/ingest/Main.scala
@@ -50,13 +50,11 @@ object Main {
         reportFolders(i) + File.separator + TEST_RUN_FILENAME
       val simLogFilePath =
         reportFolders(i) + File.separator + SIMULATION_LOG_FILENAME
-      val responseFilePath =
-        reportFolders(i) + File.separator + RESPONSE_LOG_FILENAME
       val statsFilePath =
         reportFolders(
           i
         ) + File.separator + "js" + File.separator + GLOBAL_STATS_FILENAME
-      Array(testRunFilePath, simLogFilePath, responseFilePath, statsFilePath)
+      Array(testRunFilePath, simLogFilePath, statsFilePath)
         .foreach(path => {
           if (!Files.exists(Paths.get(path))) {
             esClient.Instance.closeConnection()
@@ -72,7 +70,6 @@ object Main {
         Helper.prepareDocsForIngestion(
           statsFilePath,
           simLogFilePath,
-          responseFilePath,
           testRunFilePath
         )
 

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -4,7 +4,6 @@ import io.gatling.core.Predef._
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.protocol.HttpProtocolBuilder
 import org.kibanaLoadTest.KibanaConfiguration
-import org.kibanaLoadTest.helpers.Helper.moveResponseLogToResultsDir
 import org.kibanaLoadTest.helpers.{
   CloudHttpClient,
   Helper,

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -105,8 +105,6 @@ class BaseSimulation extends Simulation {
 
   after {
     SimulationHelper.copyRunConfigurationToReportPath()
-    // move response log from /target to gatling report folder
-    moveResponseLogToResultsDir()
     if (
       appConfig.deploymentId.isDefined && appConfig.deleteDeploymentOnFinish
     ) {

--- a/src/test/scala/org/kibanaLoadTest/test/DataStreamIngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/DataStreamIngestionTest.scala
@@ -13,7 +13,6 @@ class DataStreamIngestionTest {
 
   val simLogFilePath = new File(s"${fixturesPath()}/simulation.log.txt").getAbsolutePath
   val testRunFilePath = new File(s"${fixturesPath()}/testRun.txt").getAbsolutePath
-  val responseFilePath = new File(s"${fixturesPath()}/response.log.txt").getAbsolutePath
   val statsFilePath = new File(s"${fixturesPath()}/global_stats.json").getAbsolutePath
   val DEFAULT_INTEGRATION_TEST_DATA_STREAM = "integration-test-gatling-data"
 
@@ -23,7 +22,7 @@ class DataStreamIngestionTest {
     val client = new ESClient(config())
 
     val (requestsArray, _, _) =
-      Helper.prepareDocsForIngestion(statsFilePath, simLogFilePath, responseFilePath, testRunFilePath)
+      Helper.prepareDocsForIngestion(statsFilePath, simLogFilePath, testRunFilePath)
     logSome(1)(requestsArray)
 
     val writeData = writeAndAssert(client)(requestsArray)_
@@ -48,7 +47,7 @@ class DataStreamIngestionTest {
       .format(Helper.getSrcPath)
 
   def showFrom: () => Unit = () => {
-    val xs = simLogFilePath :: testRunFilePath :: responseFilePath :: statsFilePath :: Nil
+    val xs = simLogFilePath :: testRunFilePath :: statsFilePath :: Nil
     println(s"\n### Ingesting from:")
     xs foreach println
     println()

--- a/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/IngestionTest.scala
@@ -18,14 +18,11 @@ import org.kibanaLoadTest.helpers.{
 import org.kibanaLoadTest.ingest.Main.{
   GLOBAL_STATS_INDEX,
   SIMULATION_LOG_FILENAME,
-  RESPONSE_LOG_FILENAME,
   GLOBAL_STATS_FILENAME,
   TEST_RUN_FILENAME,
   USERS_INDEX,
   logger
 }
-
-import java.nio.file.{Files, Paths}
 
 class IngestionTest {
 
@@ -114,9 +111,6 @@ class IngestionTest {
     val testRunFilePath: String = new File(
       testPath + TEST_RUN_FILENAME
     ).getAbsolutePath
-    val responseFilePath: String = new File(
-      testPath + RESPONSE_LOG_FILENAME
-    ).getAbsolutePath
     val statsFilePath: String = new File(
       testPath + GLOBAL_STATS_FILENAME
     ).getAbsolutePath
@@ -125,7 +119,6 @@ class IngestionTest {
       Helper.prepareDocsForIngestion(
         statsFilePath,
         simLogFilePath,
-        responseFilePath,
         testRunFilePath
       )
 


### PR DESCRIPTION
## Summary

Closes #281

Unfortunately, it looks like we can't customise [StatsProcessor](https://github.com/gatling/gatling/blob/860a4b0ff9bca16c39ab4eb2ca13e567c70f35df/gatling-http/src/main/scala/io/gatling/http/engine/response/StatsProcessor.scala#L58-L76) in Gatling to log less information about call response.
Taking this into account, I disabled response logging and from now on each document will represent only request data, but not response: we were collecting request body, request headers and response code before. We can still use Gatling status (OK/KO) to identify failed requests. Valid http method / path for GenericJourney will be stored in `name` field, I will update the existing scenarios to follow the pattern.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added