### PR TITLE
update Gatling to 3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <elasticsearch.client.version>7.17.3</elasticsearch.client.version>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gatling.version>3.7.1</gatling.version>
-        <gatling-maven-plugin.version>3.1.2</gatling-maven-plugin.version>
+        <gatling.version>3.8.3</gatling.version>
+        <gatling-maven-plugin.version>4.2.5</gatling-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -155,20 +155,6 @@
                                 <arg>-language:postfixOps</arg>
                             </args>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- so maven can build a package for FrontLine -->
-            <plugin>
-                <groupId>io.gatling.frontline</groupId>
-                <artifactId>frontline-maven-plugin</artifactId>
-                <version>1.2.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

This PR updates Gatling version to the latest one: 3.8.3
Should be testing on CI, as soon as we update maven version to 3.8.6 on a worker.
### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added