### PR TITLE
Escape #|$ so gatling don't apply session values

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -73,7 +73,6 @@ object ApiCall {
             // Gatling uses #{value} syntax to pass session values, we disable it by replacing # with ##
             // $ was deprecated, but Gatling still identifies it as session attribute
             val bodyString = value.replace("#", "##").replace("$", "$$")
-            println(bodyString)
             http(requestName = s"${request.method} ${path}")
               .post(request.path)
               .body(StringBody(bodyString))


### PR DESCRIPTION
## Summary

While running scalability test with `promotion_tracking_dashboard-0182cff0-e8d8-42f1-b3c5-1f2e71dc7862.json` I faced the parsing error:

```
Caused by: io.gatling.core.session.el.ElParserException: Failed to parse {"timerange":{"timezone":"Europe/Berlin" ...
{},"searchSession":{"sessionId":"fe0c8502-ded9-43d0-b2ca-a6daa22a6717","isRestore":false,"isStored":false}}
## with error 'attribute name is missing'
```

It happens when request body in json contains a string like `#{arg0}` or `${arg0}` and Gatling interprets it as action search for `arg0` attribute in session object and pass it instead.

So the code `.body(StringBody(bodyString))` was failing since there are no attributes with searched name in the session.

The fix is to replace #|$ with ##|$$ and suggested by Gatling team.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added