### PR TITLE
Override GenericJourney config via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ In order to run it, pass json file using the following command:
 mvn gatling:test -Dgatling.simulationClass=org.kibanaLoadTest.simulation.generic.GenericJourney -DjourneyPath=<path_to_json_file>
 ```
 
+It is possible to override journey config by setting custom values via environment variables:
+KIBANA_HOST, ES_HOST, AUTH_PROVIDER_TYPE, AUTH_PROVIDER_NAME, AUTH_LOGIN, AUTH_PASSWORD
+
 ## Test results
 Gatling generates html report for each simulation run, available in `<project_root>/target/gatling/<simulation>`path
 

--- a/src/test/scala/org/kibanaLoadTest/KibanaConfiguration.scala
+++ b/src/test/scala/org/kibanaLoadTest/KibanaConfiguration.scala
@@ -228,8 +228,7 @@ object HttpClient {
         case _ => return None
       }
     } catch {
-      case _: Throwable =>
-        logger.error("Exception occurred on getting Kibana status")
+      case e:Throwable => logger.error(s"Exception occurred on getting Kibana status: ${e.getMessage}")
     } finally {
       httpClient.close()
     }
@@ -261,8 +260,7 @@ object HttpClient {
         case _ => return None
       }
     } catch {
-      case _: Throwable =>
-        logger.error("Exception occurred on getting Elasticsearch status")
+      case e:Throwable => logger.error(s"Exception occurred on getting Elasticsearch status: ${e.getMessage}")
     } finally {
       httpClient.close()
     }

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -177,12 +177,12 @@ class GenericJourney extends Simulation {
 
   // Default values are valid as long we use FTR to start Kibana server
   private val kibanaHost =
-    System.getProperty("KIBANA_HOST", "http://localhost:5620")
-  private val esHost = System.getProperty("ES_HOST", "http://localhost:9220")
-  private val providerType = System.getProperty("AUTH_PROVIDER_TYPE", "basic")
-  private val providerName = System.getProperty("AUTH_PROVIDER_NAME", "basic")
-  private val username = System.getProperty("AUTH_LOGIN", "elastic")
-  private val password = System.getProperty("AUTH_PASSWORD", "changeme")
+    sys.env.getOrElse("KIBANA_HOST", "http://localhost:5620")
+  private val esHost = sys.env.getOrElse("ES_HOST", "http://localhost:9220")
+  private val providerType = sys.env.getOrElse("AUTH_PROVIDER_TYPE", "basic")
+  private val providerName = sys.env.getOrElse("AUTH_PROVIDER_NAME", "basic")
+  private val username = sys.env.getOrElse("AUTH_LOGIN", "elastic")
+  private val password = sys.env.getOrElse("AUTH_PASSWORD", "changeme")
 
   private val config: KibanaConfiguration = new KibanaConfiguration(
     kibanaHost,


### PR DESCRIPTION
## Summary

It will be easier to use env var to override hosts and etc, at least on CI

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added