### PR TITLE
GenericJourney: support url query

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Http.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Http.scala
@@ -4,6 +4,7 @@ import spray.json.DefaultJsonProtocol
 
 case class Http(
     path: String,
+    query: Option[String],
     headers: Map[String, String],
     method: String,
     body: Option[String],
@@ -11,5 +12,5 @@ case class Http(
 )
 
 object HttpJsonProtocol extends DefaultJsonProtocol {
-  implicit val httpFormat = jsonFormat5(Http)
+  implicit val httpFormat = jsonFormat6(Http)
 }


### PR DESCRIPTION
## Summary

Follow-up to elastic/kibana#140092

This PR updates GenericJourney to use url query for API requests built on APM data.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added