### PR TITLE
GenericJourney: fix regexp for $ escape

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -74,7 +74,7 @@ object ApiCall {
             // https://gatling.io/docs/gatling/reference/current/http/request/#stringbody
             // Gatling uses #{value} syntax to pass session values, we disable it by replacing # with ##
             // $ was deprecated, but Gatling still identifies it as session attribute
-            val bodyString = value.replace("#", "##").replace("$", "$$")
+            val bodyString = value.replaceAll("\\$\\{\\{", "{{")
             http(requestName)
               .post(url)
               .body(StringBody(bodyString))


### PR DESCRIPTION
## Summary

This PR fixes escaping $ in request body: Gatling interprets `${value}` as its session value and in order to skip it I remove $ from body string and leave `{value}`
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added