### PR TITLE
Accept brotli encoding

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/HttpHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/HttpHelper.scala
@@ -151,7 +151,7 @@ class HttpHelper(config: KibanaConfiguration) {
       .acceptHeader(
         "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
       )
-      .acceptEncodingHeader("br, gzip, deflate")
+      .acceptEncodingHeader("gzip, deflate, br")
       .acceptLanguageHeader("en-GB,en-US;q=0.9,en;q=0.8")
       .userAgentHeader(
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"

--- a/src/test/scala/org/kibanaLoadTest/helpers/HttpHelper.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/HttpHelper.scala
@@ -151,7 +151,7 @@ class HttpHelper(config: KibanaConfiguration) {
       .acceptHeader(
         "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
       )
-      .acceptEncodingHeader("gzip, deflate")
+      .acceptEncodingHeader("br, gzip, deflate")
       .acceptLanguageHeader("en-GB,en-US;q=0.9,en;q=0.8")
       .userAgentHeader(
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"


### PR DESCRIPTION
## Summary

Adds "br" to the `Accept-encoding` header. This will cause performance tests to use brotli compression if Kibana supports it.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added