### PR TITLE
[Journeys] use cookie header instead of auth API call

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
@@ -189,7 +189,6 @@ class KbnClient(config: KibanaConfiguration) {
 
   def generateCookies(count: Int): List[String] = {
     val (client, connManager) = getClientAndConnectionManager(withAuth = false)
-    var cookies = List.empty[String]
     Using.resources(client, connManager) { (client, connManager) =>
       {
         // Allow specific amount of requests to be executing at once
@@ -218,9 +217,8 @@ class KbnClient(config: KibanaConfiguration) {
           case Failure(e) =>
             throw new RuntimeException("Failed to generate cookies", e)
         }
-        cookies = Await.result(requestsFuture, 120.seconds) // 2 min timeout
+        Await.result(requestsFuture, 120.seconds) // 2 min timeout
       }
     }
-    cookies
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
@@ -199,14 +199,13 @@ class KbnClient(config: KibanaConfiguration) {
         )
 
         val requestsFuture = Future.sequence(
-          List
-            .empty[Future[String]]
-            .padTo(
-              count,
+          (0 to count - 1)
+            .map(i =>
               Future {
                 getCookie(client)
               }
             )
+            .toList
         )
 
         requestsFuture.onComplete {

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
@@ -2,22 +2,22 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.scenario.{Dashboard, Login}
+import org.kibanaLoadTest.helpers.KbnClient
+import org.kibanaLoadTest.scenario.Dashboard
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class DashboardJourney extends BaseSimulation {
   val scenarioName = s"DashboardJourney"
   props.maxUsers = 500
+  val client = new KbnClient(appConfig)
+  val cookiesLst = client.generateCookies(props.maxUsers)
+  val circularFeeder = Iterator
+    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
+    .flatten
 
-  val steps = exec(
-    Login
-      .doLogin(
-        appConfig.isSecurityEnabled,
-        appConfig.loginPayload,
-        appConfig.loginStatusCode
-      )
-      .pause(5)
-  ).exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))
+  val steps = feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
+    .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))
 
   val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
   val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -2,30 +2,30 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.scenario.{Lens, Login}
+import org.kibanaLoadTest.helpers.KbnClient
+import org.kibanaLoadTest.scenario.Lens
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class LensJourney extends BaseSimulation {
   val scenarioName = "LensJourney"
   props.maxUsers = 500
+  val client = new KbnClient(appConfig)
+  val cookiesLst = client.generateCookies(props.maxUsers)
+  val circularFeeder = Iterator
+    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
+    .flatten
 
-  val steps = exec(
-    Login
-      .doLogin(
-        appConfig.isSecurityEnabled,
-        appConfig.loginPayload,
-        appConfig.loginStatusCode
-      )
-      .pause(5)
-  ).exec(
-    Lens
-      .load(
-        "c762b7a0-f5ea-11eb-a78e-83aac3c38a60",
-        appConfig.baseUrl,
-        defaultHeaders
-      )
-      .pause(5)
-  )
+  val steps = feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
+    .exec(
+      Lens
+        .load(
+          "c762b7a0-f5ea-11eb-a78e-83aac3c38a60",
+          appConfig.baseUrl,
+          defaultHeaders
+        )
+        .pause(5)
+    )
 
   val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
   val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -291,9 +291,7 @@ class GenericJourney extends Simulation {
       // Gatling automatically follow redirects in case of 301, 302, 303, 307 or 308 response status code
       // Disabling this behavior since we run the defined sequence of requests
       .disableFollowRedirect
-  private val steps = if (journey.journeyName.contains("login")) {
-    exec(scenarioSteps(journey, config))
-  } else {
+  private val steps = if (journey.needsAuthentication()) {
     val cookiesLst =
       kbnClient.generateCookies(
         journey.scalabilitySetup.getMaxConcurrentUsers()
@@ -304,7 +302,7 @@ class GenericJourney extends Simulation {
     feed(circularFeeder)
       .exec(session => session.set("Cookie", session("sidValue").as[String]))
       .exec(scenarioSteps(journey, config))
-  }
+  } else exec(scenarioSteps(journey, config))
 
   private val warmupScenario = scenarioForStage(
     steps,

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
@@ -11,7 +11,17 @@ case class Journey(
     scalabilitySetup: ScalabilitySetup,
     testData: Option[TestData],
     streams: List[RequestStream]
-)
+) {
+  def needsAuthentication(): Boolean = {
+    !streams
+      .map(stream =>
+        stream.requests
+          .map(req => req.getRequestUrl())
+          .contains("/internal/security/login")
+      )
+      .contains(true)
+  }
+}
 
 object JourneyJsonProtocol extends DefaultJsonProtocol {
   implicit val journeyFormat = jsonFormat5(Journey)

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
@@ -12,6 +12,11 @@ case class Journey(
     testData: Option[TestData],
     streams: List[RequestStream]
 ) {
+
+  /**
+    * Returns true if any stream contains auth API call, otherwise falls
+    * This functions is used to check if journey does authentication itself or requires pre-generated Cookie.
+    */
   def needsAuthentication(): Boolean = {
     !streams
       .map(stream =>

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Request.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Request.scala
@@ -1,7 +1,15 @@
 package org.kibanaLoadTest.simulation.generic.mapping
 
 import org.kibanaLoadTest.helpers.Helper
-import spray.json.{DefaultJsonProtocol, JsNumber, JsString, JsValue, JsonFormat, RootJsonFormat, deserializationError}
+import spray.json.{
+  DefaultJsonProtocol,
+  JsNumber,
+  JsString,
+  JsValue,
+  JsonFormat,
+  RootJsonFormat,
+  deserializationError
+}
 
 import java.util.Date
 import org.kibanaLoadTest.simulation.generic.mapping.HttpJsonProtocol._
@@ -9,7 +17,9 @@ import org.kibanaLoadTest.simulation.generic.mapping.HttpJsonProtocol._
 case class Request(
     http: Http,
     date: Date
-)
+) {
+  def getRequestUrl(): String = http.path
+}
 
 object DateJsonProtocol extends DefaultJsonProtocol {
   implicit object DateJsonFormat extends JsonFormat[Date] {

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/ScalabilitySetup.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/ScalabilitySetup.scala
@@ -7,7 +7,10 @@ case class ScalabilitySetup(
     warmup: List[Step],
     test: List[Step],
     maxDuration: String
-)
+) {
+  def getMaxConcurrentUsers(): Int =
+    (this.warmup ::: this.test).map(step => step.getMaxUsersCount).max
+}
 
 object ScalabilitySetupJsonProtocol extends DefaultJsonProtocol {
   implicit val scalabilityFormat = jsonFormat3(ScalabilitySetup)

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Step.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Step.scala
@@ -9,6 +9,16 @@ case class Step(
     maxUsersCount: Option[Int],
     duration: Option[String]
 ) {
+  def getMaxUsersCount: Int = {
+    userCount match {
+      case Some(value) => value
+      case None =>
+        maxUsersCount match {
+          case Some(value) => value
+          case None        => 0
+        }
+    }
+  }
   override def toString: String = {
     val users = userCount match {
       case Some(count) => s"[$count]"

--- a/src/test/scala/org/kibanaLoadTest/test/KibanaAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/KibanaAPITest.scala
@@ -1,7 +1,7 @@
 package org.kibanaLoadTest.test
 
 import org.apache.http.impl.client.HttpClientBuilder
-import org.junit.jupiter.api.Assertions.{assertDoesNotThrow}
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertTrue}
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.api.function.Executable
@@ -71,5 +71,14 @@ class KibanaAPITest {
     val httpClient = HttpClientBuilder.create.build
     val loginClosure: Executable = () => helper.loginIfNeeded(httpClient)
     assertDoesNotThrow(loginClosure, "helper.loginIfNeeded throws exception")
+  }
+
+  @Test
+  def generateCookiesTest(): Unit = {
+    val cookieCount = 1000
+    val client = new KbnClient(config)
+    val cookieLst = client.generateCookies(cookieCount)
+    assertEquals(cookieCount, cookieLst.length)
+    assertTrue(cookieLst(0).startsWith("sid=Fe26.2"))
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/test/KibanaAPITest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/KibanaAPITest.scala
@@ -1,7 +1,12 @@
 package org.kibanaLoadTest.test
 
 import org.apache.http.impl.client.HttpClientBuilder
-import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{
+  assertDoesNotThrow,
+  assertEquals,
+  assertNotEquals,
+  assertTrue
+}
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.api.function.Executable
@@ -80,5 +85,6 @@ class KibanaAPITest {
     val cookieLst = client.generateCookies(cookieCount)
     assertEquals(cookieCount, cookieLst.length)
     assertTrue(cookieLst(0).startsWith("sid=Fe26.2"))
+    assertNotEquals(cookieLst(0), cookieLst(1), "cookies must be unique")
   }
 }


### PR DESCRIPTION
## Summary

Closes #325

This PR adds capability to run journey without making login call but setting Cookie header. GenericJourney will now check if "/internal/security/login" is listed in json file. If so, the journey will be run as before. If not, cookies will be generated based on max number of concurrent users and individually passed to each virtual user session.

This PR also updates some of existing journeys to skip login API request and start directly with main flow (**LensJourney, CanvasJourney, DashboardJourney and DiscoverJourney**)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added