### PR TITLE
use 1 session

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
@@ -188,6 +188,9 @@ class KbnClient(config: KibanaConfiguration) {
   }
 
   def generateCookies(count: Int): List[String] = {
+    if (count < 1) {
+      throw new IllegalArgumentException("'count' must be above 0")
+    }
     val (client, connManager) = getClientAndConnectionManager(withAuth = false)
     Using.resources(client, connManager) { (client, connManager) =>
       {
@@ -199,7 +202,7 @@ class KbnClient(config: KibanaConfiguration) {
         )
 
         val requestsFuture = Future.sequence(
-          (0 to count - 1)
+          (1 to count)
             .map(i =>
               Future {
                 getCookie(client)

--- a/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/BaseSimulation.scala
@@ -8,6 +8,7 @@ import org.kibanaLoadTest.helpers.{
   CloudHttpClient,
   Helper,
   HttpHelper,
+  KbnClient,
   SimulationHelper
 }
 import org.kibanaLoadTest.scenario.Login
@@ -68,6 +69,16 @@ class BaseSimulation extends Simulation {
     // use existing deployment or local instance
   } else
     new KibanaConfiguration(Helper.readResourceConfigFile(envConfig))
+
+  /**
+    * It does not make any difference to use unique cookie for individual user (tcp connection), unless we test Kibana
+    * security service. Taking it into account, we create a single session and share it.
+    */
+  val client = new KbnClient(appConfig)
+  val cookiesLst = client.generateCookies(1)
+  val circularFeeder = Iterator
+    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
+    .flatten
 
   val httpHelper = new HttpHelper(appConfig)
   var httpProtocol: HttpProtocolBuilder = httpHelper.getProtocol

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/CanvasJourney.scala
@@ -7,18 +7,12 @@ import io.gatling.core.Predef.{
   scenario
 }
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.helpers.KbnClient
 import org.kibanaLoadTest.scenario.Canvas
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class CanvasJourney extends BaseSimulation {
   val scenarioName = "CanvasJourney"
   props.maxUsers = 200
-  val client = new KbnClient(appConfig)
-  val cookiesLst = client.generateCookies(5)
-  val circularFeeder = Iterator
-    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
-    .flatten
 
   val steps = feed(circularFeeder)
     .exec(session => session.set("Cookie", session("sidValue").as[String]))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DashboardJourney.scala
@@ -2,18 +2,12 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.helpers.KbnClient
 import org.kibanaLoadTest.scenario.Dashboard
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class DashboardJourney extends BaseSimulation {
   val scenarioName = s"DashboardJourney"
   props.maxUsers = 500
-  val client = new KbnClient(appConfig)
-  val cookiesLst = client.generateCookies(5)
-  val circularFeeder = Iterator
-    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
-    .flatten
 
   val steps = feed(circularFeeder)
     .exec(session => session.set("Cookie", session("sidValue").as[String]))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DemoJourney.scala
@@ -9,15 +9,9 @@ class DemoJourney extends BaseSimulation {
   val scenarioName = "DemoJourney"
   props.maxUsers = 200
 
-  val steps = exec(
-    Login
-      .doLogin(
-        appConfig.isSecurityEnabled,
-        appConfig.loginPayload,
-        appConfig.loginStatusCode
-      )
-      .pause(5)
-  ).exec(Home.load(appConfig.baseUrl, defaultHeaders).pause(10))
+  val steps = feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
+    .exec(Home.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Discover.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Discover.do2ExtraQueries(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/DiscoverJourney.scala
@@ -2,18 +2,12 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.helpers.KbnClient
 import org.kibanaLoadTest.scenario.Discover
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class DiscoverJourney extends BaseSimulation {
   val scenarioName = "DiscoverJourney"
   props.maxUsers = 500
-  val client = new KbnClient(appConfig)
-  val cookiesLst = client.generateCookies(5)
-  val circularFeeder = Iterator
-    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
-    .flatten
 
   val steps = feed(circularFeeder)
     .exec(session => session.set("Cookie", session("sidValue").as[String]))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LensJourney.scala
@@ -2,18 +2,12 @@ package org.kibanaLoadTest.simulation.branch
 
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
-import org.kibanaLoadTest.helpers.KbnClient
 import org.kibanaLoadTest.scenario.Lens
 import org.kibanaLoadTest.simulation.BaseSimulation
 
 class LensJourney extends BaseSimulation {
   val scenarioName = "LensJourney"
   props.maxUsers = 500
-  val client = new KbnClient(appConfig)
-  val cookiesLst = client.generateCookies(5)
-  val circularFeeder = Iterator
-    .continually(cookiesLst.map(i => Map("sidValue" -> i)))
-    .flatten
 
   val steps = feed(circularFeeder)
     .exec(session => session.set("Cookie", session("sidValue").as[String]))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/LongRunJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/LongRunJourney.scala
@@ -11,15 +11,8 @@ class LongRunJourney extends BaseSimulation {
   props.maxUsers = 200
 
   val scn: ScenarioBuilder = scenario(scenarioName)
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
+  val steps = feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
     .exec(Home.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Discover.load(appConfig.baseUrl, defaultHeaders).pause(10))
     .exec(Dashboard.load(appConfig.baseUrl, defaultHeaders).pause(10))

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBGaugeJourney.scala
@@ -9,25 +9,19 @@ class TSVBGaugeJourney extends BaseSimulation {
   val scenarioName = "GaugeJourney"
   props.maxUsers = 500
 
-  val steps = exec(
-    Login
-      .doLogin(
-        appConfig.isSecurityEnabled,
-        appConfig.loginPayload,
-        appConfig.loginStatusCode
-      )
-      .pause(5)
-  ).exec(
-    Visualize
-      .load(
-        "tsvb",
-        "b80e6540-b891-11e8-a6d9-e546fe2bba5f",
-        "data/visualize/gauge_sold_per_day.json",
-        appConfig.baseUrl,
-        defaultHeaders
-      )
-      .pause(5)
-  )
+  val steps = feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
+    .exec(
+      Visualize
+        .load(
+          "tsvb",
+          "b80e6540-b891-11e8-a6d9-e546fe2bba5f",
+          "data/visualize/gauge_sold_per_day.json",
+          appConfig.baseUrl,
+          defaultHeaders
+        )
+        .pause(5)
+    )
 
   val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
   val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TSVBTimeSeriesJourney.scala
@@ -9,15 +9,10 @@ class TSVBTimeSeriesJourney extends BaseSimulation {
   val scenarioName = s"TimeSeriesJourney"
   props.maxUsers = 500
 
-  val steps = exec(
-    Login
-      .doLogin(
-        appConfig.isSecurityEnabled,
-        appConfig.loginPayload,
-        appConfig.loginStatusCode
-      )
-      .pause(5)
-  ).exec(
+  val steps = feed(circularFeeder)
+    .exec(session =>
+      session.set("Cookie", session("sidValue").as[String])
+    ) exec (
     Visualize
       .load(
         "tsvb",
@@ -27,7 +22,7 @@ class TSVBTimeSeriesJourney extends BaseSimulation {
         defaultHeaders
       )
       .pause(5)
-  )
+    )
 
   val warmupScn: ScenarioBuilder = scenario("warmup").exec(steps)
   val scn: ScenarioBuilder = scenario(scenarioName).exec(steps)

--- a/src/test/scala/org/kibanaLoadTest/simulation/branch/TelemetryAPIJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/branch/TelemetryAPIJourney.scala
@@ -9,61 +9,52 @@ class TelemetryAPIJourney extends BaseSimulation {
   def scenarioName(module: String): String = {
     s"Branch telemetry journey $module ${appConfig.buildVersion}"
   }
-  
-  val scnTelemetry1: ScenarioBuilder = scenario(scenarioName("First hit - non-cached encrypted usage"))
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(TelemetryAPI.load(appConfig.baseUrl, defaultHeaders).pause(1))
 
-  val scnTelemetry2: ScenarioBuilder = scenario(scenarioName("Second+ hit - cached encrypted usage"))
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
-    )
-    .exec(TelemetryAPI.cached(appConfig.baseUrl, defaultHeaders).pause(1))
+  val scnTelemetry1: ScenarioBuilder =
+    scenario(scenarioName("First hit - non-cached encrypted usage"))
+      .feed(circularFeeder)
+      .exec(session => session.set("Cookie", session("sidValue").as[String]))
+      .exec(TelemetryAPI.load(appConfig.baseUrl, defaultHeaders).pause(1))
 
-  val scnTelemetry3: ScenarioBuilder = scenario(scenarioName("Example flyout - non-cached non-encrypted usage, check collectors status"))
-    .exec(
-      Login
-        .doLogin(
-          appConfig.isSecurityEnabled,
-          appConfig.loginPayload,
-          appConfig.loginStatusCode
-        )
-        .pause(5)
+  val scnTelemetry2: ScenarioBuilder =
+    scenario(scenarioName("Second+ hit - cached encrypted usage"))
+      .feed(circularFeeder)
+      .exec(session => session.set("Cookie", session("sidValue").as[String]))
+      .exec(TelemetryAPI.cached(appConfig.baseUrl, defaultHeaders).pause(1))
+
+  val scnTelemetry3: ScenarioBuilder = scenario(
+    scenarioName(
+      "Example flyout - non-cached non-encrypted usage, check collectors status"
     )
-    .exec(TelemetryAPI.getUnencryptedStats(appConfig.baseUrl, defaultHeaders).pause(1))
+  ).feed(circularFeeder)
+    .exec(session => session.set("Cookie", session("sidValue").as[String]))
+    .exec(
+      TelemetryAPI
+        .getUnencryptedStats(appConfig.baseUrl, defaultHeaders)
+        .pause(1)
+    )
 
   val cachedMaxUsers = 250
   val nonCachedMaxUsers = 30
   val duringDuration = 60 * 3
 
   setUp(
-    scnTelemetry1.inject(
-      constantConcurrentUsers(20) during (duringDuration),
-      rampConcurrentUsers(20) to nonCachedMaxUsers during (duringDuration)
-    ).andThen(
-      scnTelemetry2.inject(
-        constantConcurrentUsers(20) during (duringDuration),
-        rampConcurrentUsers(20) to cachedMaxUsers during (duringDuration)
-      )
-    ).andThen(
-      scnTelemetry3.inject(
+    scnTelemetry1
+      .inject(
         constantConcurrentUsers(20) during (duringDuration),
         rampConcurrentUsers(20) to nonCachedMaxUsers during (duringDuration)
       )
-    )
+      .andThen(
+        scnTelemetry2.inject(
+          constantConcurrentUsers(20) during (duringDuration),
+          rampConcurrentUsers(20) to cachedMaxUsers during (duringDuration)
+        )
+      )
+      .andThen(
+        scnTelemetry3.inject(
+          constantConcurrentUsers(20) during (duringDuration),
+          rampConcurrentUsers(20) to nonCachedMaxUsers during (duringDuration)
+        )
+      )
   ).protocols(httpProtocol).maxDuration(props.simulationTimeout * 2)
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -299,10 +299,11 @@ class GenericJourney extends Simulation {
       // Disabling this behavior since we run the defined sequence of requests
       .disableFollowRedirect
   private val steps = if (journey.needsAuthentication()) {
-    val cookiesLst =
-      kbnClient.generateCookies(
-        journey.scalabilitySetup.getMaxConcurrentUsers()
-      )
+    /**
+      * It does not make any difference to use unique cookie for individual user (tcp connection), unless we test Kibana
+      * security service. Taking it into account, we create a single session and share it.
+      */
+    val cookiesLst = kbnClient.generateCookies(1)
     val circularFeeder = Iterator
       .continually(cookiesLst.map(i => Map("sidValue" -> i)))
       .flatten


### PR DESCRIPTION
## Summary

According to Kibana security folks, it does not make any difference to use unique cookie for individual user (tcp connection), unless we test Kibana. Since I saw instability during running 100+ concurrent session creating, this PR limits it to 1 per scalability journey run.

I also updated other existing journeys to use generated session cookie instead of login api call.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added