### PR TITLE
make startTime/endTime optional for stream

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/RequestStream.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/RequestStream.scala
@@ -7,8 +7,8 @@ import org.kibanaLoadTest.simulation.generic.mapping.DateJsonProtocol._
 import java.util.Date
 
 case class RequestStream(
-    startTime: Date,
-    endTime: Date,
+    startTime: Option[Date],
+    endTime: Option[Date],
     requests: List[Request]
 )
 


### PR DESCRIPTION
## Summary

There is not need to define stream start/endTime for single apis testing, this PR makes them optional.
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added