### PR TITLE
[GenericJourney] support incrementUsersPerSec for scalability testing

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/core/ApiCall.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/core/ApiCall.scala
@@ -19,7 +19,7 @@ object ApiCall {
       exec(httpParentRequest)
     } else {
       val childHttpRequests: Seq[HttpRequestBuilder] =
-        (children.map(request => httpRequest(request.http, config))).toSeq
+        children.map(request => httpRequest(request.http, config))
       exec(httpParentRequest.resources(childHttpRequests: _*))
     }
   }

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/core/JourneyBuilder.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/core/JourneyBuilder.scala
@@ -24,7 +24,8 @@ object JourneyBuilder {
     "rampUsers" -> "open",
     "rampUsersPerSec" -> "open",
     "constantUsersPerSec" -> "open",
-    "stressPeakUsers" -> "open"
+    "stressPeakUsers" -> "open",
+    "incrementUsersPerSec" -> "open"
   )
 
   /**
@@ -78,6 +79,13 @@ object JourneyBuilder {
         rampUsersPerSec(step.minUsersCount.get)
           .to(step.maxUsersCount.get)
           .during(getDuration(step.duration.get))
+      case "incrementUsersPerSec" =>
+        incrementUsersPerSec(step.userCount.get.toDouble)
+          .times(step.times.get)
+          .eachLevelLasting(getDuration(step.duration.get))
+          .separatedByRampsLasting(getDuration(step.duration.get))
+          .startingFrom(step.userCount.get.toDouble)
+
       case _ =>
         throw new IllegalArgumentException(
           s"Invalid open model: ${step.action}"

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Step.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Step.scala
@@ -7,6 +7,7 @@ case class Step(
     userCount: Option[Int],
     minUsersCount: Option[Int],
     maxUsersCount: Option[Int],
+    times: Option[Int],
     duration: Option[String]
 ) {
   def getMaxUsersCount: Int = {
@@ -21,7 +22,12 @@ case class Step(
   }
   override def toString: String = {
     val users = userCount match {
-      case Some(count) => s"[$count]"
+      case Some(count) =>
+        times match {
+          case Some(times) =>
+            s"[start from [$count] and ramp by [$count] users every [$times]"
+          case None => s"[$count]"
+        }
       case None =>
         maxUsersCount match {
           case Some(maxCount) =>
@@ -45,5 +51,5 @@ case class Step(
 }
 
 object StepJsonProtocol extends DefaultJsonProtocol {
-  implicit val stepFormat = jsonFormat5(Step)
+  implicit val stepFormat = jsonFormat6(Step)
 }


### PR DESCRIPTION
## Summary

I recent spotted [this](https://gatling.io/docs/gatling/reference/current/core/injection/#meta-dsl) example of scalability testing in Gatling docs and think it can be a good approach for our single apis testing 
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added