### PR TITLE
support single api capacity testing

### DIFF
--- a/src/test/resources/test/single_api_journey.json
+++ b/src/test/resources/test/single_api_journey.json
@@ -1,0 +1,46 @@
+{
+  "journeyName": "POST /api/core/capabilities",
+  "scalabilitySetup": {
+    "warmup": [
+      {
+        "action": "constantUsersPerSec",
+        "userCount": 10,
+        "duration": "30s"
+      }
+    ],
+    "test": [
+      {
+        "action": "rampUsersPerSec",
+        "minUsersCount": 10,
+        "maxUsersCount": 250,
+        "duration": "1m"
+      }
+    ],
+    "maxDuration": "10m"
+  },
+  "testData": {
+    "esArchives": [],
+    "kbnArchives": []
+  },
+  "streams": [
+    {
+      "requests": [
+        {
+          "http": {
+            "method": "POST",
+            "path": "/api/core/capabilities",
+            "query": "?useDefaultCapabilities=true",
+            "body": "{\"applications\":[\"error\",\"status\",\"kibana\",\"dev_tools\",\"r\",\"short_url_redirect\",\"home\",\"management\",\"space_selector\",\"security_access_agreement\",\"security_capture_url\",\"security_login\",\"security_logout\",\"security_logged_out\",\"security_overwritten_session\",\"security_account\",\"reportingRedirect\",\"graph\",\"discover\",\"integrations\",\"fleet\",\"ingestManager\",\"visualize\",\"canvas\",\"dashboards\",\"lens\",\"maps\",\"osquery\",\"observability-overview\",\"ml\",\"uptime\",\"synthetics\",\"securitySolutionUI\",\"siem\",\"logs\",\"metrics\",\"infra\",\"monitoring\",\"enterpriseSearch\",\"enterpriseSearchContent\",\"enterpriseSearchAnalytics\",\"elasticsearch\",\"appSearch\",\"workplaceSearch\",\"searchExperiences\",\"apm\",\"ux\",\"kibanaOverview\"]}",
+            "headers": {
+              "Cookie": "",
+              "Kbn-Version": "",
+              "Accept-Encoding": "gzip, deflate, br",
+              "Content-Type": "application/json"
+            },
+            "statusCode": 200
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/GenericJourney.scala
@@ -111,11 +111,11 @@ class GenericJourney extends Simulation {
 
   private val warmupScenario = JourneyBuilder.buildScenario(
     httpSteps,
-    s"warmup for ${journey.journeyName} ${config.version}"
+    s"warmup: ${journey.journeyName} ${config.version}"
   )
   private val testScenario = JourneyBuilder.buildScenario(
     httpSteps,
-    s"test for ${journey.journeyName} ${config.version}"
+    s"test: ${journey.journeyName} ${config.version}"
   )
 
   setUp(

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Journey.scala
@@ -7,7 +7,7 @@ import spray.json.DefaultJsonProtocol
 
 case class Journey(
     journeyName: String,
-    kibanaVersion: String,
+    kibanaVersion: Option[String],
     scalabilitySetup: ScalabilitySetup,
     testData: Option[TestData],
     streams: List[RequestStream]

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Request.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Request.scala
@@ -16,7 +16,7 @@ import org.kibanaLoadTest.simulation.generic.mapping.HttpJsonProtocol._
 
 case class Request(
     http: Http,
-    date: Date
+    date: Option[Date]
 ) {
   def getRequestUrl(): String = http.path
 }

--- a/src/test/scala/org/kibanaLoadTest/test/JourneyTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/JourneyTest.scala
@@ -1,0 +1,36 @@
+package org.kibanaLoadTest.test
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+import org.kibanaLoadTest.helpers.Helper
+import org.kibanaLoadTest.simulation.generic.mapping.Journey
+import org.kibanaLoadTest.simulation.generic.mapping.JourneyJsonProtocol._
+
+import scala.io.Source.fromFile
+import scala.util.Using
+import spray.json._
+
+class JourneyTest {
+  @Test
+  def singleAPIJourneyLoadTest(): Unit = {
+    val filePath =
+      getClass.getResource("/test/single_api_journey.json").getFile
+    val journeyJson =
+      Using(fromFile(filePath)) { f =>
+        f.getLines().mkString("\n")
+      }
+    val journey = journeyJson.get.parseJson.convertTo[Journey]
+
+    assertEquals("POST /api/core/capabilities", journey.journeyName)
+    assertEquals(journey.streams.length, 1)
+    assertEquals(journey.streams(0).requests.length, 1)
+    val http = journey.streams(0).requests(0).http
+    assertEquals(http.method, "POST")
+    assertEquals(http.path, "/api/core/capabilities")
+    assertEquals(http.query.get, "?useDefaultCapabilities=true")
+    assertTrue(http.body.isDefined)
+    assertEquals(http.headers.get("Kbn-Version").get, "")
+    assertEquals(http.statusCode, 200)
+  }
+
+}


### PR DESCRIPTION
## Summary

This PR updates Journey mappings to support single api journey json format. 
Test with json loading example is added too.
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [x] Unit tests are added