### PR TITLE
Revert "Bump gatling.version from 3.8.4 to 3.9.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <elasticsearch.client.version>8.5.2</elasticsearch.client.version>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gatling.version>3.9.0</gatling.version>
+        <gatling.version>3.8.4</gatling.version>
         <gatling-maven-plugin.version>4.2.9</gatling-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
Reverts elastic/kibana-load-testing#354

```
  | 2023-01-07 14:06:02 UTC  HEAD is now at 525074e Bump gatling.version from 3.8.4 to 3.9.0 (#354)
  | 2023-01-07 14:06:02 UTC | [ERROR] /var/lib/buildkite-agent/builds/kb-static-scalability-01/elastic/kibana-scalability-benchmarking/kibana/kibana-load-testing/src/test/scala/IDEPathHelper.scala:9: error: value ancestor is not a member of java.nio.file.Path
  | 2023-01-07 14:06:06 UTC | [ERROR]   val projectRootDir = gatlingConfUrl.ancestor(3)
  | 2023-01-07 14:06:06 UTC | [ERROR]                                       ^
  | 2023-01-07 14:06:06 UTC | [ERROR] 1 error
  | 2023-01-07 14:06:10 UTC | [ERROR] exception compilation error occurred!!!
  | 2023-01-07 14:06:10 UTC | org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
  | 2023-01-07 14:06:10 UTC | at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
  | 2023-01-07 14:06:10 UTC | at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
  | 2023-01-07 14:06:10 UTC | at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:153)
  | 2023-01-07 14:06:10 UTC | at scala_maven_executions.JavaMainCallerByFork.run (JavaMainCallerByFork.java:95)
  | 2023-01-07 14:06:10 UTC | at scala_maven.ScalaCompilerSupport.compile (ScalaCompilerSupport.java:173)
  | 2023-01-07 14:06:10 UTC | at scala_maven.ScalaCompilerSupport.doExecute (ScalaCompilerSupport.java:86)
  | 2023-01-07 14:06:10 UTC | at scala_maven.ScalaMojoSupport.execute (ScalaMojoSupport.java:310)
  | 2023-01-07 14:06:10 UTC | at scala_maven.ScalaTestCompileMojo.execute (ScalaTestCompileMojo.java:51)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
  | 2023-01-07 14:06:10 UTC | at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
  | 2023-01-07 14:06:10 UTC | at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
  | 2023-01-07 14:06:10 UTC | at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
  | 2023-01-07 14:06:10 UTC | at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
  | 2023-01-07 14:06:10 UTC | at java.lang.reflect.Method.invoke (Method.java:568)
  | 2023-01-07 14:06:10 UTC | at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
  | 2023-01-07 14:06:10 UTC | at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
  | 2023-01-07 14:06:10 UTC | at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
  | 2023-01-07 14:06:10 UTC | at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
  | 2023-01-07 14:06:10 UTC | [ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.8.0:testCompile (default) on project kibana-load-test: scala compilation failed -> [Help 1]
  | 2023-01-07 14:06:10 UTC | [ERROR]
  | 2023-01-07 14:06:10 UTC | [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
  | 2023-01-07 14:06:10 UTC | [ERROR] Re-run Maven using the -X switch to enable full debug logging.
  | 2023-01-07 14:06:10 UTC | [ERROR]
  | 2023-01-07 14:06:10 UTC | [ERROR] For more information about the errors and possible solutions, please read the following articles:
  | 2023-01-07 14:06:10 UTC | [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
  | 2023-01-07 14:06:10 UTC | 🚨 Error: The command exited with status 1
```
