### PR TITLE
[GenericJourney] add -DskipCleanupOnTeardown flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ mvn gatling:test -Dgatling.simulationClass=org.kibanaLoadTest.simulation.generic
 It is possible to override journey config by setting custom values via environment variables:
 KIBANA_HOST, ES_URL, AUTH_PROVIDER_TYPE, AUTH_PROVIDER_NAME, AUTH_LOGIN, AUTH_PASSWORD
 
+It is possible to skip unloading kbn & es archives on journey teardown (e.g. you want to inspect Kibana):
+```
+-DskipCleanupOnTeardown=true
+```
+
 ## Test results
 Gatling generates html report for each simulation run, available in `<project_root>/target/gatling/<simulation>`path
 


### PR DESCRIPTION
## Summary

Since we restart Kibana & ES for each scalability journey, we can save time by skipping unloading data archives.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added