### PR TITLE
[GenericJourney] add optional timeout per end-point

### DIFF
--- a/src/test/resources/test/single_api_journey.json
+++ b/src/test/resources/test/single_api_journey.json
@@ -37,7 +37,8 @@
               "Accept-Encoding": "gzip, deflate, br",
               "Content-Type": "application/json"
             },
-            "statusCode": 200
+            "statusCode": 200,
+            "timeout": 10000
           }
         }
       ]

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/core/ApiCall.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/core/ApiCall.scala
@@ -6,6 +6,7 @@ import io.gatling.http.Predef._
 import io.gatling.http.request.builder.HttpRequestBuilder
 import org.kibanaLoadTest.KibanaConfiguration
 import org.kibanaLoadTest.simulation.generic.mapping
+import scala.concurrent.duration.DurationInt
 
 object ApiCall {
   def execute(
@@ -55,7 +56,7 @@ object ApiCall {
            .replaceAll("[^\\/]+\\d{10,}", config.buildNumber.toString)
            .replaceAll("\\{buildNumber}", config.buildNumber.toString)
        else request.path) + request.query.getOrElse("")
-    request.method match {
+    val requestBuilder = request.method match {
       case "GET" =>
         http(requestName)
           .get(url)
@@ -93,6 +94,11 @@ object ApiCall {
           .check(status.is(request.statusCode))
       case _ =>
         throw new IllegalArgumentException(s"Invalid method ${request.method}")
+    }
+    if (request.timeout.isDefined) {
+      requestBuilder.requestTimeout(request.timeout.get.milli)
+    } else {
+      requestBuilder
     }
   }
 }

--- a/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Http.scala
+++ b/src/test/scala/org/kibanaLoadTest/simulation/generic/mapping/Http.scala
@@ -8,9 +8,10 @@ case class Http(
     headers: Map[String, String],
     method: String,
     body: Option[String],
-    statusCode: Int
+    statusCode: Int,
+    timeout: Option[Int]
 )
 
 object HttpJsonProtocol extends DefaultJsonProtocol {
-  implicit val httpFormat = jsonFormat6(Http)
+  implicit val httpFormat = jsonFormat7(Http)
 }

--- a/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/HelpersTest.scala
@@ -34,7 +34,7 @@ class HelpersTest {
       Helper.readResourceConfigFile("config/local.conf")
     )
     assertEquals(config.baseUrl, "http://localhost:5620")
-    assertEquals(config.buildVersion, "8.5.0")
+    assertTrue(!config.buildVersion.isEmpty)
     assertEquals(config.isSecurityEnabled, true)
     assertEquals(config.loginStatusCode, 200)
     assertEquals(

--- a/src/test/scala/org/kibanaLoadTest/test/JourneyTest.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/JourneyTest.scala
@@ -31,6 +31,7 @@ class JourneyTest {
     assertTrue(http.body.isDefined)
     assertEquals(http.headers.get("Kbn-Version").get, "")
     assertEquals(http.statusCode, 200)
+    assertEquals(http.timeout.get, 10000)
   }
 
 }


### PR DESCRIPTION
## Summary

Currently we use global request timeout (60000 ms) for all api calls. It is set in `gatling.conf`.
https://github.com/elastic/kibana-load-testing/blob/main/src/test/resources/gatling.conf#L80

In some case we would like to set custom request timeout per end-point e.g. increasing it up to 2 minutes.

Update your request in api journey with `timeout` property:

```
        {
          "http": {
            "method": "POST",
            "path": "/api/telemetry/v2/clusters/_stats",
            "body": "{}",
            "headers": {
              "Cookie": "",
              "Kbn-Version": "",
              "Accept-Encoding": "gzip, deflate, br",
              "Content-Type": "application/json"
            },
            "statusCode": 200,
            "timeout": 120000
          }
        }
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added