### PR TITLE
Es archiver/delete existing index

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/ESArchiver.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESArchiver.scala
@@ -6,6 +6,7 @@ import io.circe.syntax.EncoderOps
 import org.kibanaLoadTest.KibanaConfiguration
 import org.kibanaLoadTest.helpers.Helper.checkFilesExist
 import org.slf4j.{Logger, LoggerFactory}
+
 import java.nio.file.{Path, Paths}
 
 case class Doc(indexType: String, name: String, source: Json)
@@ -60,7 +61,7 @@ class ESArchiver(config: KibanaConfiguration, bulkSize: Int = 1000) {
         case 1 =>
           val index = indexArray.last
           logger.info(s"[$archivePath] Creating ${index.name} index")
-          client.createIndex(index.name, index.source)
+          client.forceCreateIndex(index.name, index.source)
           logger.info(s"[$archivePath] Indexing docs")
           client.bulk(
             index.name,

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.java
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.java
@@ -113,7 +113,7 @@ public class ESClient {
             if (ex.getMessage().matches(".*\\[resource_already_exists_exception\\] index.*already exists$")) {
                 this.deleteIndex(indexName);
                 this.createIndex(indexName, source);
-            }
+            } else throw ex;
         }
     }
 

--- a/src/test/scala/org/kibanaLoadTest/helpers/ESClient.java
+++ b/src/test/scala/org/kibanaLoadTest/helpers/ESClient.java
@@ -68,6 +68,11 @@ public class ESClient {
         return INSTANCE;
     }
 
+    /**
+     * This function creates index and returns exception if index already exists.
+     * @param indexName index name
+     * @param source json with settings, mappings
+     */
     public void createIndex(String indexName, Json source) {
         CreateIndexRequest req = CreateIndexRequest.of(b -> b.index(indexName).withJson(new StringReader(source.toString())));
         try {
@@ -78,7 +83,7 @@ public class ESClient {
                 logger.error(String.format("Failed to create index '%s'", indexName));
             }
         } catch (IOException | ElasticsearchException ex) {
-            throw new RuntimeException(String.format("Failed to create index '%s'", indexName), ex);
+            throw new RuntimeException(ex);
         }
     }
 
@@ -92,7 +97,23 @@ public class ESClient {
                 logger.error(String.format("Failed to delete index '%s'", indexName));
             }
         } catch (IOException | ElasticsearchException ex) {
-            throw new RuntimeException(String.format("Failed to delete index '%s'", indexName), ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * This function will delete index if it exists, and create a new one.
+     * @param indexName index name
+     * @param source json with settings, mappings
+     */
+    public void forceCreateIndex(String indexName, Json source) {
+        try {
+            this.createIndex(indexName, source);
+        } catch (RuntimeException ex) {
+            if (ex.getMessage().matches(".*\\[resource_already_exists_exception\\] index.*already exists$")) {
+                this.deleteIndex(indexName);
+                this.createIndex(indexName, source);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR copies logic from kibana es-archiver to retry on index creation failure: delete the existing index and create a new one.