### PR TITLE
Remove association of component with Buildkite system

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,7 +20,6 @@ metadata:
 spec:
   type: service
   owner: group:appex-qa
-  system: buildkite
   lifecycle: production
 
 # Declare the prod Buildkite pipeline


### PR DESCRIPTION
The [Buildkite system](https://backstage.elastic.dev/catalog-graph?rootEntityRefs%5B%5D=system%3Adefault%2Fbuildkite&maxDepth=1&selectedKinds%5B%5D=api&selectedKinds%5B%5D=component&selectedKinds%5B%5D=domain&selectedKinds%5B%5D=group&selectedKinds%5B%5D=location&selectedKinds%5B%5D=system&selectedKinds%5B%5D=template&selectedKinds%5B%5D=user&unidirectional=true&mergeRelations=true&direction=LR&showFilters=true) in Backstage has a few components declared underneath it like this one that probably don't belong there. This is completely understandable because we're all new to Backstage, and it's easy to copy/paste fields like this. I'm proposing this change to help tidy that up. 😄

## Summary

Summarize your PR.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added