### PR TITLE
[ci] make integration tests run only if unit tests pass

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,12 @@
 steps:
   - label: ":mvn: run unit tests"
     command: .buildkite/scripts/run-unit-tests.sh
+    key: unit-tests
     agents:
       image: maven:3.8.6-openjdk-11
 
-  - wait
-
   - label: ":mvn: run integration tests on Cloud deployment"
     command: .buildkite/scripts/run-integration-tests.sh
+    depends_on: unit-tests
     agents:
       image: maven:3.8.6-openjdk-11


### PR DESCRIPTION
## Summary

Optimising pipeline to skip integration tests if step with unit tests failed

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added