### PR TITLE
add more tests for kbnClient

### DIFF
--- a/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
+++ b/src/test/scala/org/kibanaLoadTest/helpers/KbnClient.scala
@@ -83,7 +83,10 @@ class KbnClient(
               val regExp = "\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?".r
               regExp.findFirstIn(responseStr) match {
                 case Some(version) => this.version = version
-                case None => throw new RuntimeException("Cannot parse kbn-version in login html page")
+                case None =>
+                  throw new RuntimeException(
+                    "Cannot parse kbn-version in login html page"
+                  )
               }
             case Failure(error) => throw new RuntimeException(error)
           }
@@ -104,7 +107,11 @@ class KbnClient(
     } match {
       case Success(response) =>
         if (response.getStatusLine.getStatusCode == 200) {
-          response.getHeaders("set-cookie")(0).getValue.split(";")(0)
+          Option(response.getFirstHeader("set-cookie")) match {
+            case Some(value) => value.getValue.split(";")(0)
+            case _ =>
+              throw new RuntimeException("Response has no 'set-cookie' header")
+          }
         } else {
           throw new RuntimeException(
             s"Failed to login: ${response.getStatusLine}"

--- a/src/test/scala/org/kibanaLoadTest/test/mocks/KibanaMockServer.scala
+++ b/src/test/scala/org/kibanaLoadTest/test/mocks/KibanaMockServer.scala
@@ -2,7 +2,12 @@ package org.kibanaLoadTest.test.mocks
 
 import org.mockserver.configuration.Configuration
 import org.mockserver.integration.ClientAndServer
-import org.mockserver.model.{ClearType, HttpResponse, RequestDefinition}
+import org.mockserver.model.{
+  ClearType,
+  HttpResponse,
+  MediaType,
+  RequestDefinition
+}
 import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.HttpTemplate.{TemplateType, template}
@@ -91,6 +96,23 @@ class KibanaMockServer(port: Int) {
       )
   }
 
+  def createForbiddenLoginCallback() = {
+    server
+      .clear(
+        request.withPath("/internal/security/login").withMethod("POST"),
+        ClearType.EXPECTATIONS
+      ) // clear previous behaviour, if any
+      .when(
+        request()
+          .withMethod("POST")
+          .withPath("/internal/security/login")
+      )
+      .respond(
+        response()
+          .withStatusCode(403)
+      )
+  }
+
   def createAddSampleDataCallback(
       dataType: String,
       docsCount: Int = 4675,
@@ -136,5 +158,36 @@ class KibanaMockServer(port: Int) {
     if (server != null && server.isRunning()) {
       stopQuietly(server)
     }
+  }
+
+  def createBadLoginHtmlPageCallback() = {
+    server
+      .clear(
+        request.withMethod("GET").withPath("/login"),
+        ClearType.EXPECTATIONS
+      )
+      .when(request().withMethod("GET").withPath("/login"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withBody("Please upgrade your browser", MediaType.TEXT_HTML)
+      )
+  }
+
+  def createNoCookieInHeadersLoginCallback() = {
+    server
+      .clear(
+        request.withPath("/internal/security/login").withMethod("POST"),
+        ClearType.EXPECTATIONS
+      ) // clear previous behaviour, if any
+      .when(
+        request()
+          .withMethod("POST")
+          .withPath("/internal/security/login")
+      )
+      .respond(
+        response()
+          .withStatusCode(200)
+      )
   }
 }


### PR DESCRIPTION
## Summary

Adding more tests for kbnClient to test login failure handling.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Branch is successfully tested on [Kibana CI](https://kibana-ci.elastic.co/job/elastic+kibana+load-testing/)
- [ ] Unit tests are added